### PR TITLE
Phase one analysis

### DIFF
--- a/asf_next_three_million_heat_pump_owners/config/base.yaml
+++ b/asf_next_three_million_heat_pump_owners/config/base.yaml
@@ -785,3 +785,7 @@ raw_data_path:
   /mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2.
   Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov
   survey data/SAV for Experian (Nesta Heat Pumps survey) 29 11.3.2025 - LABEL.xlsx
+wales_raw_data_path:
+  /mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2.
+  Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov
+  survey data/Wales boost/SAV for Experian (Nesta Heat Pumps survey) 29 13.5.2025 - LABEL.xlsx

--- a/asf_next_three_million_heat_pump_owners/getters/load_data.py
+++ b/asf_next_three_million_heat_pump_owners/getters/load_data.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from asf_next_three_million_heat_pump_owners import config
+
+
+def get_analysis_ready_data(
+    uk_data_path: str = f"""/mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2. Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov survey data/Analysis ready data/20250409_yougov_survey_clean_data.parquet""",
+    wales_data_path: str = f"""/mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2. Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov survey data/Analysis ready data/20250514_yougov_survey_clean_data_wales_boost.parquet""",
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+
+    return pd.read_parquet(uk_data_path, engine="pyarrow"), pd.read_parquet(
+        wales_data_path
+    )

--- a/asf_next_three_million_heat_pump_owners/notebooks/clean_raw_data_wales_boost.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/clean_raw_data_wales_boost.py
@@ -1,0 +1,2101 @@
+# %%
+import pandas as pd
+from datetime import datetime
+import yaml
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.utils import cleaning
+from asf_next_three_million_heat_pump_owners import PROJECT_DIR
+
+# %% [markdown]
+# ### Load raw data
+
+# %%
+data = pd.read_excel(
+    config.get("wales_raw_data_path"),
+    header=[0, 1],
+    sheet_name="SAV for Experian (Nesta Heat Pu",
+    keep_default_na=False,
+    na_values=[" "],
+)
+
+# %% [markdown]
+# ### Raw data info
+
+# %%
+data.info()
+
+# %% [markdown]
+# ### Column cleaning and asserting data types
+#
+# The question code and full question are loaded as multiindex headers. For code brevity, the question code is kept as the column header and the full question is dropped. When the full question needs to be accessed, use the look-up dictionary `code_question_lookup`. The look-up dictionary is then stored in `config/base.yaml`.
+
+# %%
+# Create lookup dictionary for question code and full question
+code_question_lookup = {col[0]: col[1] for col in data.columns}
+
+# Remove second index (full question) of multi-index header
+data.columns = data.columns.get_level_values(0)
+
+# %% [markdown]
+# #### Record number
+# - Response type: integers [min: 0, max: 7022]
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert from int64 to int16
+
+# %%
+data["RecordNo"] = data["RecordNo"].astype("int16")
+
+# %% [markdown]
+# #### Weights
+# - Response type: float [0.706321514591228 to 4.89409862643]
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to float
+
+# %%
+data["weight"] = data["weight"].astype(float)
+
+# %% [markdown]
+# #### Do you own or rent the home in which you live?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Replace encoded characters
+#     - Convert to categorical
+
+# %%
+data["profile_house_tenure"] = data["profile_house_tenure"].replace(
+    to_replace="–", value="-", regex=True
+)
+
+# %%
+data["profile_house_tenure"] = pd.Categorical(
+    data["profile_house_tenure"],
+    categories=[
+        "Own - outright",
+        "Own - with a mortgage",
+        "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+        "Rent - from a private landlord",
+        "Rent - from my local authority",
+        "Rent - from a housing association",
+        "Neither - I live with my parents, family or friends but pay some rent to them",
+        "Neither - I live rent-free with my parents, family or friends",
+        "Other",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_house_tenure")
+
+# %% [markdown]
+# #### UK regions and countries lived in [calculated from postcode]
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["profile_GOR"] = pd.Categorical(
+    data["profile_GOR"],
+    categories=[
+        "East Midlands",
+        "East of England",
+        "London",
+        "North East",
+        "North West",
+        "South East",
+        "South West",
+        "West Midlands",
+        "Yorkshire and the Humber",
+        "Wales",
+        "Scotland",
+        "Northern Ireland",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_GOR")
+
+# %% [markdown]
+# #### How many people, including yourself, are there in your household? Please include both adults and children.
+# - Response type: Integers or text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert all integers to strings
+#     - Convert to categorical
+
+# %%
+# Convert all to strings
+data["profile_household_size"] = data["profile_household_size"].map(str)
+
+# %%
+data["profile_household_size"] = pd.Categorical(
+    data["profile_household_size"],
+    categories=[
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8 or more",
+        "Don't know",
+        "Prefer not to say",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_household_size")
+
+# %% [markdown]
+# #### What ethnic group best describes you? Please select one option only. (We ask the question in this way so that it is consistent with Census definitions.)
+# - Response type: Text strings
+# - Number of NA: 7 (Cannot identify whether they whether these were not asked based on a condition, or whether they were asked and did not give any answer)
+# - Cleaning:
+#     - Keep NaN as empty
+#     - Convert to categorical
+
+# %%
+data["ethnicity_new"] = pd.Categorical(
+    data["ethnicity_new"],
+    categories=[
+        "English / Welsh / Scottish / Northern Irish / British",  # White
+        "Irish",  # White
+        "Gypsy or Irish Traveller",  # White
+        "Any other White background",  # White
+        "White and Black Caribbean",  # Mixed / Multiple ethnic groups
+        "White and Black African",  # Mixed / Multiple ethnic groups
+        "White and Asian",  # Mixed / Multiple ethnic groups
+        "Any other Mixed / Multiple ethnic background",  # Mixed / Multiple ethnic groups
+        "Indian",  # Asian / Asian British
+        "Pakistani",  # Asian / Asian British
+        "Bangladeshi",  # Asian / Asian British
+        "Chinese",  # Asian / Asian British
+        "Any other Asian background",  # Asian / Asian British
+        "African",  # Black / African / Caribbean / Black British
+        "Caribbean",  # Black / African / Caribbean / Black British
+        "Any other Black / African / Caribbean background",  # Black / African / Caribbean / Black British
+        "Arab",  # Other ethnic group
+        "Any other ethnic group",  # Other ethnic group
+        "Prefer not to say",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "ethnicity_new")
+
+# %% [markdown]
+# #### Gross HOUSEHOLD income is the combined income of all those earners in a household from all sources, including wages, salaries, or rents and before tax deductions. What is your gross household income?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning
+#     - Replace encoded charactesr
+#     - Convert to categorical
+
+# %%
+data["profile_gross_household"] = data["profile_gross_household"].replace(
+    to_replace="Â", value="", regex=True
+)
+
+# %%
+data["profile_gross_household"] = pd.Categorical(
+    data["profile_gross_household"],
+    categories=[
+        "under £5,000 per year",
+        "£5,000 to £9,999 per year",
+        "£10,000 to £14,999 per year",
+        "£15,000 to £19,999 per year",
+        "£20,000 to £24,999 per year",
+        "£25,000 to £29,999 per year",
+        "£30,000 to £34,999 per year",
+        "£35,000 to £39,999 per year",
+        "£40,000 to £44,999 per year",
+        "£45,000 to £49,999 per year",
+        "£50,000 to £59,999 per year",
+        "£60,000 to £69,999 per year",
+        "£70,000 to £99,999 per year",
+        "£100,000 to £149,999 per year",
+        "£150,000 and over",
+        "Don't know",
+        "Prefer not to answer",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_gross_household")
+
+# %% [markdown]
+# #### What is the highest educational or work-related qualification you have?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["profile_education_level"] = pd.Categorical(
+    data["profile_education_level"],
+    categories=[
+        "No formal qualifications",
+        "Youth training certificate/skillseekers",
+        "Recognised trade apprenticeship completed",
+        "Clerical and commercial",
+        "City & Guilds certificate",
+        "City & Guilds certificate - advanced",
+        "ONC",
+        "CSE grades 2-5",
+        "CSE grade 1, GCE O level, GCSE, School Certificate",
+        "Scottish Ordinary/ Lower Certificate",
+        "GCE A level or Higher Certificate",
+        "Scottish Higher Certificate",
+        "Nursing qualification (e.g. SEN, SRN, SCM, RGN)",
+        "Teaching qualification (not degree)",
+        "University diploma",
+        "University or CNAA first degree (e.g. BA, B.Sc, B.Ed)",
+        "University or CNAA higher degree (e.g. M.Sc, Ph.D)",
+        "Other technical, professional or higher qualification",
+        "Don't know",
+        "Prefer not to say",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_education_level")
+
+# %% [markdown]
+# #### Which, if any, of the following types of home best describes where you currently live?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["house_type"] = pd.Categorical(
+    data["house_type"],
+    categories=[
+        "Detached house",
+        "Semi-detached house",
+        "Terraced house",
+        "Maisonette",
+        "Studio/flat/apartment",
+        "Bungalow",
+        "Static Caravan/mobile home/trailer",
+        "Other",
+        "Don't know",
+        "Prefer not to say",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "house_type")
+
+# %% [markdown]
+# #### Thinking about your home (i.e. your main place of residence)...  Which of the following best describes the age of your house (i.e. when it was built)?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["PEN_PropertyAge"] = pd.Categorical(
+    data["PEN_PropertyAge"],
+    categories=[
+        "Pre 1920",
+        "1920-1944",
+        "1945-1964",
+        "1965-1982",
+        "1983-2002",
+        "Post 2003",
+        "Don't know",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_PropertyAge")
+
+# %% [markdown]
+# #### How many bedrooms does your home have in total?
+# - Response type: Integers or text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert all to string
+#     - Convert to categorical
+
+# %%
+# Convert all to strings
+data["PEN_Bedrooms"] = data["PEN_Bedrooms"].map(str)
+
+# %%
+data["PEN_Bedrooms"] = pd.Categorical(
+    data["PEN_Bedrooms"],
+    categories=[
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6 or more",
+        "Don't know",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Bedrooms")
+
+# %% [markdown]
+# #### Approximately, how large is the floor space in your home? (Please type your answer in square metres in the box below. If you are unsure, please give your best estimate)
+#
+#
+
+# %% [markdown]
+# "pen_floorsize_ab_range"
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Replace "DK" with "Don't know"
+#     - Convert to categorical
+
+# %% [markdown]
+# Note: Full UK dataset had field "PEN_Floorsize_AB" which is missing from the Wales boost
+
+# %%
+data["pen_floorsize_ab_range"] = data["pen_floorsize_ab_range"].replace(
+    to_replace="DK", value="Don't know"
+)
+
+# %%
+data["pen_floorsize_ab_range"] = pd.Categorical(
+    data["pen_floorsize_ab_range"],
+    categories=[
+        "37 - 500",
+        "500 - 1,000",
+        "1,000 - 2,000",
+        "2,000 - 3,000",
+        "3,000 - 5,000",
+        "5,000 - 7,000",
+        "7,000 - 10,000",
+        "Don't know",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "pen_floorsize_ab_range")
+
+# %% [markdown]
+# #### Central heating is a central system that generates heat for multiple rooms… What type of central heating does your home have? (Please select all that apply. If there is no central heating in your home, please select the ‘Not applicable’ option)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 0
+#     - Cleaning:
+#         - Convert to boolean, except _open1 where convert to string
+#         - Recode "Other" free text responses that should be classified in one of the given types
+#
+# - _1 Mains gas
+# - _2 Tank or bottled gas
+# - _3 Heat pump
+# - _4 Electric (all others excluding heat pump, including storage heaters)
+# - _5 Oil
+# - _6 Wood (e.g. logs, waste wood or pellets)
+# - _7 Solid fuel (e.g. coal)
+# - _8 Renewable energy (e.g. solar thermal)
+# - _9 District or communal heat network
+# - _955 Other
+# - _977 Don't know
+# - _944 Not applicable - There is no central heating in my home
+# - _open1 What type of central heating does you home have? -Other
+
+# %%
+# Modify full question labels in lookup
+pen_q2_options = [option for option in code_question_lookup.keys() if "Q2_" in option]
+for option in pen_q2_options:
+    code_question_lookup[option] = (
+        "Central heating is a central system that generates heat for multiple rooms… What type of central heating does your home have? (Please select all that apply. If there is no central heating in your home, please select the 'Not applicable' option): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+pen_q2_options = [option for option in code_question_lookup.keys() if "Q2_" in option]
+for option in pen_q2_options:
+    if option != "PEN_Q2_open1":
+        data[option] = data[option].map({"Yes": True, "No": False})
+    else:
+        data[option] = data[option].map(str)
+
+# %%
+## Recoding free text responses
+
+# Create recoded versions of each column
+for option in pen_q2_options:
+    if option != "PEN_Q2_open1":
+        data[f"{option}_recoded"] = data[option].copy()
+
+# %%
+# There are five free text responses to inspect
+data["PEN_Q2_open1"].value_counts(dropna=False)
+
+# %%
+# Indices of responses that selected "Other" in addition to one of the specified options
+other_plus_indices = data.index[
+    data["PEN_Q2_955"]
+    & (
+        data["PEN_Q2_1"]
+        | data["PEN_Q2_2"]
+        | data["PEN_Q2_3"]
+        | data["PEN_Q2_4"]
+        | data["PEN_Q2_5"]
+        | data["PEN_Q2_6"]
+        | data["PEN_Q2_7"]
+        | data["PEN_Q2_8"]
+        | data["PEN_Q2_9"]
+        | data["PEN_Q2_977"]
+        | data["PEN_Q2_944"]
+    )
+]
+
+# %%
+## Invalid free text responses
+invalid_responses_q2 = ["O", "In"]
+
+invalid_responses_q2_indices = data[
+    data["PEN_Q2_open1"].isin(invalid_responses_q2)
+].index
+
+# Create a new column for invalid responses
+data["PEN_Q2_invalid_recoded"] = False
+
+# If an invalid free response is given but a given option was selected, change their "Other" response to False
+for i in invalid_responses_q2_indices:
+    if i in other_plus_indices:
+        data.loc[i, "PEN_Q2_955_recoded"] = False
+
+# If an invalid free response is given and no other option was selected, change their "Other" response to False and add an "Invalid response" column with "True"
+# Note all respondents with an invalid free text response selected another option so new "invalid" column is empty but keep code for future changes
+for i in invalid_responses_q2_indices:
+    if i not in other_plus_indices:
+        data.loc[i, "PEN_Q2_955_recoded"] = False
+        data.loc[i, "PEN_Q2_invalid_recoded"] = True  # Invalid
+
+# %%
+## Electric responses
+electric_responses_q2 = [
+    "Electric",
+]
+electric_responses_q2_indices = data[
+    data["PEN_Q2_open1"].isin(electric_responses_q2)
+].index
+
+# Change "Other" option to False and ensure/change "Electric" to True
+for i in electric_responses_q2_indices:
+    data.loc[i, "PEN_Q2_955_recoded"] = False
+    data.loc[i, "PEN_Q2_4_recoded"] = True  # Electric
+
+# %%
+## Gas responses (assume all refer to mains)
+gas_responses_q2 = [
+    "Combi boiler",  # Assume gas combi
+]
+gas_responses_q2_indices = data[data["PEN_Q2_open1"].isin(gas_responses_q2)].index
+
+# Change "Other" option to False and ensure/change "Mains gas" to True
+for i in gas_responses_q2_indices:
+    data.loc[i, "PEN_Q2_955_recoded"] = False
+    data.loc[i, "PEN_Q2_1_recoded"] = True  # Mains gas
+
+# %%
+## Heat pump responses
+heat_pump_responses_q2 = [
+    "Hybrid boiler, gas and heat pump",
+]
+heat_pump_responses_q2_indices = data[
+    data["PEN_Q2_open1"].isin(heat_pump_responses_q2)
+].index
+
+# Change "Other" option to False and ensure/change "Heat pump" to True
+for i in heat_pump_responses_q2_indices:
+    data.loc[i, "PEN_Q2_955_recoded"] = False
+    data.loc[i, "PEN_Q2_3_recoded"] = True  # Heat pump
+
+# %%
+# Update question lookup for new recoded columns
+for option in pen_q2_options:
+    if option != "PEN_Q2_open1":
+        recoded_col = f"{option}_recoded"
+        code_question_lookup[recoded_col] = code_question_lookup.get(option)
+
+code_question_lookup["PEN_Q2_invalid_recoded"] = (
+    "Central heating is a central system that generates heat for multiple rooms… What type of central heating does your home have? (Please select all that apply. If there is no central heating in your home, please select the ‘Not applicable’ option): Invalid response"
+)
+
+# %%
+# Check changes from recoding for each option
+q2_col_pairs = {}
+for option in pen_q2_options:
+    if option != "PEN_Q2_open1":
+        q2_col_pairs[option] = f"{option}_recoded"
+
+q2_col_pairs["PEN_Q2_invalid"] = "PEN_Q2_invalid_recoded"
+
+
+count_comparison = {}
+for original_col, recoded_col in q2_col_pairs.items():
+
+    if original_col in data.columns and recoded_col in data.columns:
+        counts_original = data[original_col].value_counts()
+        counts_recoded = data[recoded_col].value_counts()
+        count_comparison[recoded_col] = {
+            "Original True": counts_original.get(True, 0),
+            "Recoded True": counts_recoded.get(True, 0),
+            "Original False": counts_original.get(False, 0),
+            "Recoded False": counts_recoded.get(False, 0),
+        }
+    elif original_col not in data.columns:
+        counts_recoded = data[recoded_col].value_counts()
+        count_comparison[recoded_col] = {
+            "Original True": 0,
+            "Recoded True": counts_recoded.get(True, 0),
+            "Original False": 0,
+            "Recoded False": counts_recoded.get(False, 0),
+        }
+
+count_comparison_df = pd.DataFrame(count_comparison).T
+count_comparison_df["Option"] = (
+    count_comparison_df.index.map(code_question_lookup).str.split(":").str[1]
+)
+
+count_comparison_df
+
+# %%
+q2_recoded_summary = count_comparison_df[["Recoded True", "Recoded False"]].copy()
+q2_recoded_summary["Percentage of respondents: True"] = (
+    q2_recoded_summary["Recoded True"] / len(data)
+) * 100
+q2_recoded_summary["Percentage of respondents: False"] = (
+    q2_recoded_summary["Recoded False"] / len(data)
+) * 100
+q2_recoded_summary[
+    ["Percentage of respondents: True", "Percentage of respondents: False"]
+] = q2_recoded_summary[
+    ["Percentage of respondents: True", "Percentage of respondents: False"]
+].round(
+    2
+)
+q2_recoded_summary["Option"] = (
+    count_comparison_df.index.map(code_question_lookup).str.split(":").str[1]
+)
+
+q2_recoded_summary
+
+# %% [markdown]
+# #### How old is your current central heating system?
+# - Response type: Text strings
+# - Number of NA: 9 (Not asked as they answered Not applicable to Q2 (do not have central heating))
+# - Cleaning:
+#     - Recode NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_CurrentHeatingsystem_new"] = data["PEN_CurrentHeatingsystem_new"].fillna(
+    "Not asked"
+)
+
+# %%
+data["PEN_CurrentHeatingsystem_new"] = pd.Categorical(
+    data["PEN_CurrentHeatingsystem_new"],
+    categories=[
+        "0-5 years",
+        "6-10 years",
+        "10-15 years",
+        "More than 15 years",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_CurrentHeatingsystem_new")
+
+# %% [markdown]
+# #### Still thinking about heating your home...  Approximately, for how long have you been using your current heating system?
+# - Response type: Text strings
+# - Number of NA: 9 (Not asked as they answered Not applicable to Q2 (do not have central heating))
+# - Cleaning:
+#     - Recode NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Heating"] = data["PEN_Heating"].fillna("Not asked")
+
+# %%
+data["PEN_Heating"] = pd.Categorical(
+    data["PEN_Heating"],
+    categories=[
+        "0-5 years",
+        "6-10 years",
+        "10-15 years",
+        "More than 15 years",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Heating")
+
+# %% [markdown]
+# #### EPC (Energy Performance Certificate) is a rating scheme that summarises the energy efficiency of homes, commercial and industrial properties... It uses a scale from 'A' (Very efficient) to 'G' (Inefficient) and the higher the rating, the more energy efficient your home is...  Before taking this survey, had you ever heard of EPC?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+# Update lookup with full question
+code_question_lookup["PEN_EPCawareness"] = (
+    "EPC (Energy Performance Certificate) is a rating scheme that summarises the energy efficiency of homes, commercial and industrial properties... It uses a scale from 'A' (Very efficient) to 'G' (Inefficient) and the higher the rating, the more energy efficient your home is...  Before taking this survey, had you ever heard of EPC?"
+)
+
+# %%
+data["PEN_EPCawareness"] = pd.Categorical(
+    data["PEN_EPCawareness"],
+    categories=[
+        "Yes, I had",
+        "No, I had not",
+        "Don't know",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_EPCawareness")
+
+# %% [markdown]
+# #### To the best of your knowledge, what is the current EPC grade of your home?
+# - Response type: Text strings
+# - Number of NA: 154 (Not asked if they answered "No, I had not" (103) or "Don't know" (51) to PEN_EPCawareness)
+# - Cleaning:
+#     - Convert NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_EPCgradenew"] = data["PEN_EPCgradenew"].fillna("Not asked")
+
+# %%
+data["PEN_EPCgradenew"] = pd.Categorical(
+    data["PEN_EPCgradenew"],
+    categories=["A", "B", "C", "D", "E", "F", "G", "Don't know", "Not asked"],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_EPCgradenew")
+
+# %% [markdown]
+# #### Does your home have a gas meter for 'mains gas'?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["PEN_Q1"] = pd.Categorical(
+    data["PEN_Q1"],
+    categories=[
+        "Yes, it does",
+        "No, it does not",
+        "Don't know",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q1")
+
+# %% [markdown]
+# #### Which ONE of the following BEST describes the main type of central heating at your home?
+# Respondents are asked to choose one from the options they selected in Q10 (PEN_Q2) if they chose more than 1.
+#
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Replace "$PENQ2open1" with "Other"
+#     - Convert to categorical
+#     - Create a recoded version of this question that matches the recoded PEN_Q2
+
+# %%
+data["PEN_Q2Anew"].value_counts(dropna=False)
+
+# %%
+data["PEN_Q2Anew"] = data["PEN_Q2Anew"].replace(to_replace="$PENQ2open1", value="Other")
+
+# %%
+## Other responses
+other_responses_q2a_indices = data["PEN_Q2Anew"].index[data["PEN_Q2Anew"] == "Other"]
+
+# Create new recoded version of column
+data["PEN_Q2Anew_recoded"] = data["PEN_Q2Anew"]
+
+# Recode responses if they were recoded in PEN_Q2
+for i in other_responses_q2a_indices:
+    if data["PEN_Q2_955_recoded"][i] == False:  # recoded to another option
+
+        if data["PEN_Q2_1_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Mains gas"
+
+        if data["PEN_Q2_2_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Tank or bottled gas"
+
+        if data["PEN_Q2_3_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Heat pump"
+
+        if data["PEN_Q2_4_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = (
+                "Electric (all others excluding heat pump, including storage heaters)"
+            )
+
+        if data["PEN_Q2_5_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Oil"
+
+        if data["PEN_Q2_6_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = (
+                "Wood (e.g. logs, waste wood or pellets)"
+            )
+
+        if data["PEN_Q2_7_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Solid fuel (e.g. coal)"
+
+        if data["PEN_Q2_8_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Renewable energy (e.g. solar thermal)"
+
+        if data["PEN_Q2_9_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "District or communal heat network"
+
+        if data["PEN_Q2_977_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = "Don't know"
+
+        if data["PEN_Q2_944_recoded"][i] == True:
+            data.loc[i, "PEN_Q2Anew_recoded"] = (
+                "Not applicable - There is no central heating in my home"
+            )
+
+# %%
+data["PEN_Q2Anew"] = pd.Categorical(
+    data["PEN_Q2Anew"],
+    categories=[
+        "Mains gas",
+        "Tank or bottled gas",
+        "Heat pump",
+        "Electric (all others excluding heat pump, including storage heaters)",
+        "Oil",
+        "Wood (e.g. logs, waste wood or pellets)",
+        "Solid fuel (e.g. coal)",
+        "Renewable energy (e.g. solar thermal)",
+        "District or communal heat network",
+        "Other",
+        "Don't know",
+        "Not applicable - There is no central heating in my home",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q2Anew")
+
+# %%
+data["PEN_Q2Anew_recoded"] = pd.Categorical(
+    data["PEN_Q2Anew_recoded"],
+    categories=[
+        "Mains gas",
+        "Tank or bottled gas",
+        "Heat pump",
+        "Electric (all others excluding heat pump, including storage heaters)",
+        "Oil",
+        "Wood (e.g. logs, waste wood or pellets)",
+        "Solid fuel (e.g. coal)",
+        "Renewable energy (e.g. solar thermal)",
+        "District or communal heat network",
+        "Other",
+        "Don't know",
+        "Not applicable - There is no central heating in my home",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q2Anew_recoded")
+
+# %% [markdown]
+# #### Which, if any, of the following does your home have? (Please select all that apply)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 0
+#     - Cleaning:
+#         - Convert to boolean
+#
+# - _1 Private outdoor space
+# - _2 Electric Vehicle (EV)
+# - _3 An EV charger
+# - _4 A hot water cylinder
+# - _5 Space for a hot water cylinder
+# - _6 Underfloor heating (not electric)
+# - _7 An induction hob
+# - _8 Solar panels
+# - _9 Home battery
+# - _10 A gas or oil boiler older than 10 years
+# - _966 None of these
+# - _977 Don't know
+#
+
+# %%
+# Modify full question labels in lookup
+pen_q3_options = [option for option in code_question_lookup.keys() if "Q3_" in option]
+for option in pen_q3_options:
+    code_question_lookup[option] = (
+        "Which, if any, of the following does your home have? (Please select all that apply): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+for option in pen_q3_options:
+    data[option] = data[option].map({"Yes": True, "No": False})
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data, pen_q3_options, "PEN_Q3_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["PEN_Q3_collapsed"] = (
+    "Which, if any, of the following does your home have? (Please select all that apply)"
+)
+
+# %%
+summary_rows = []
+for col in pen_q3_options:
+    temp = (
+        pd.Series(pd.Categorical(data[col], [True, False]), name=col)
+        .to_frame()
+        .assign(weight=data["weight"])
+    )
+
+    summary_rows.append(
+        summary.create_single_question_summary_frame(temp, col)
+        .reset_index()
+        .melt(id_vars="index")
+        .assign(
+            column=lambda df: df["index"].astype(str).str.cat(df["variable"], sep="_")
+        )
+        .loc[:, ["column", "value"]]
+        .set_index("column")
+        .T.reset_index(drop=True)
+        .rename_axis(None, axis=1)
+        .rename(index={0: col})
+    )
+
+q3_counts_df = pd.concat(summary_rows)
+q3_counts_df
+
+# %% [markdown]
+# #### Before taking this survey, had you ever heard of heat pumps as a home heating system? (Please select the option that best applies)
+# - Response type: Text strings
+# - Number of NA: 15 - Not asked because they selected "Heat pump" in Q2 (have a heat pump)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q4"] = data["PEN_Q4"].fillna("Not asked")
+
+# %%
+data["PEN_Q4"] = pd.Categorical(
+    data["PEN_Q4"],
+    categories=[
+        "I have heard of heat pumps, and I know what they are",
+        "I have heard of heat pumps, but I don't know what they are",
+        "I have never heard of heat pumps",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q4")
+
+# %% [markdown]
+# #### Before taking this survey, have you ever seen what a heat pump looks like?
+# - Response type: Text strings
+# - Number of NA: 74 - Have a heat pump (Q2, n=15); Have never heard of heat pumps (Q4, n=59)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q6"] = data["PEN_Q6"].fillna("Not asked")
+
+# %%
+data["PEN_Q6"] = pd.Categorical(
+    data["PEN_Q6"],
+    categories=[
+        "Yes, I have",
+        "No, I haven't",
+        "Don't know/ can't recall",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q6")
+
+# %% [markdown]
+# #### Have you ever been to a home that has a heat pump?
+# - Response type: Text strings
+# - Number of NA: 74 - Have a heat pump (Q2, n=15); Have never heard of heat pumps (Q4, n=59)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q7"] = data["PEN_Q7"].fillna("Not asked")
+
+# %%
+data["PEN_Q7"] = pd.Categorical(
+    data["PEN_Q7"],
+    categories=[
+        "Yes, I have",
+        "No, I haven't",
+        "Don't know/ can't recall",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q7")
+
+# %% [markdown]
+# #### Does anyone in your family, close friends or neighbours own a heat pump?
+# - Response type: Text strings
+# - Number of NA: 74 - Have a heat pump (Q2, n=15); Have never heard of heat pumps (Q4, n=59)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q8"] = data["PEN_Q8"].fillna("Not asked")
+
+# %%
+data["PEN_Q8"] = pd.Categorical(
+    data["PEN_Q8"],
+    categories=[
+        "Yes, they do",
+        "No, they do not",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q8")
+
+# %% [markdown]
+# #### Have you ever had a conversation with your family, close friends or neighbours about installing a heat pump in your home?
+# - Response type: Text strings
+# - Number of NA: 74 - Have a heat pump (Q2, n=15); Have never heard of heat pumps (Q4, n=59)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q9"] = data["PEN_Q9"].fillna("Not asked")
+
+# %%
+data["PEN_Q9"] = pd.Categorical(
+    data["PEN_Q9"],
+    categories=[
+        "Yes, I have",
+        "No, I haven't",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q9")
+
+# %% [markdown]
+# #### For the following questions, please imagine that in the next 5 years...(i.e. from now till February 2030), you want to install a central heating system for your home/ your current heating system needs replacing...A heat pump can heat a home. An outside unit (see picture) takes heat from the air, concentrates it, and puts it into radiators. It's like a fridge in reverse. It works effectively in all weather conditions, including on cold days. Heat pumps run on electricity so differ to boilers, which run on fossil fuels (gas or oil). This means that heat pumps can run using electricity that is generated from renewable resources, such as wind or sun, which do not produce carbon emissions...How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source? (Please select the option that best applies. Even if you are not currently a homeowner, we are still interested in your opinion.)
+# - Response type: Text strings
+# - Number of NA: 15 - Not asked because they selected "Heat pump" in Q2 (have a heat pump)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q5"] = data["PEN_Q5"].fillna("Not asked")
+
+# %%
+data["PEN_Q5"] = pd.Categorical(
+    data["PEN_Q5"],
+    categories=[
+        "Definitely would consider",
+        "Probably would consider",
+        "Probably wouldn't consider",
+        "Definitely wouldn't consider",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q5")
+
+# %% [markdown]
+# #### Upgrading from a fossil fuel boiler to an air source heat pump can cost £12,000 for a typical home. Often smaller, modern homes cost a bit less and larger older homes a bit more. In England, Wales and Scotland, grants are available of up to £7,500 to lower the cost of first-time heat pump installations...  To what extent, if at all, would installing a heat pump be affordable for your household, without taking out additional borrowing?
+# - Response type: Text strings
+# - Number of NA: 15 - Not asked because they selected "Heat pump" in Q2 (have a heat pump)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q5Anew"] = data["PEN_Q5Anew"].fillna("Not asked")
+
+# %%
+data["PEN_Q5Anew"] = pd.Categorical(
+    data["PEN_Q5Anew"],
+    categories=[
+        "Very affordable",
+        "Fairly affordable",
+        "Fairly unaffordable",
+        "Very unaffordable",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q5Anew")
+
+# %% [markdown]
+# #### How willing, if at all, would you be to borrow funds from a mortgage provider to fund the installation of low carbon heating (such as heat pumps) in your home? (This could involve extending your existing mortgage or taking out a small additional mortgage)
+# - Response type: Text strings
+# - Number of NA: 207 - only asked those who do not own a heat pump (did not select Heat pump in Q2) AND are homeowners (selected one of the "Own" options in profile_house_tenure)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q5Bnew"] = data["PEN_Q5Bnew"].fillna("Not asked")
+
+# %%
+data["PEN_Q5Bnew"] = pd.Categorical(
+    data["PEN_Q5Bnew"],
+    categories=[
+        "Very willing",
+        "Fairly willing",
+        "Not very willing",
+        "Not at all willing",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q5Bnew")
+
+# %% [markdown]
+# #### How willing, if at all, would you be to take out unsecured borrowing (e.g. via a personal loan or credit card) in order to fund the installation of low carbon heating (such as heat pumps) in your home?
+# - Response type: Text strings
+# - Number of NA: 207 - only asked those who do not own a heat pump (did not select Heat pump in Q2) AND are homeowners (selected one of the "Own" options in profile_house_tenure)
+# - Cleaning:
+#     - Change NaN to "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q5Cnew"] = data["PEN_Q5Cnew"].fillna("Not asked")
+
+# %%
+data["PEN_Q5Cnew"] = pd.Categorical(
+    data["PEN_Q5Cnew"],
+    categories=[
+        "Very willing",
+        "Fairly willing",
+        "Not very willing",
+        "Not at all willing",
+        "Don't know",
+        "Not asked",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q5Cnew")
+
+# %% [markdown]
+# #### Which, if any, of the following factors do you think would prevent you from installing a heat pump in your home? (Please select all that apply. If there is no specific barrier towards installing a heat pump in your home, please select the "Not applicable" option)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 207 - only asked those who do not own a heat pump (did not select Heat pump in Q2) AND are homeowners (selected one of the "Own" options in profile_house_tenure)
+#     - Cleaning:
+#         - Convert "Yes"/"False" to "True"/"False" (strings)
+#         - Replace NaN with "Not asked" (string)
+#
+# - _1 Too expensive to install
+# - _2 Not convinced that the technology is good enough to heat my home
+# - _3 Wouldn't be appropriate for my property
+# - _4 I worry I may end up paying more for my energy bills
+# - _5 Difficulty finding a trader I trust to install it
+# - _6 I don't have enough information to make an informed decision
+# - _7 Too much hassle to research and find an installer
+# - _8 Too much disruption to my home
+# - _9 Planning permission
+# - _10 I'm not the decision-maker about energy in my household
+# - _11 Others in my household would need to be convinced
+# - _12 I am happy with my current heating system and don't see any reason to change it
+# - _13 I am planning to move home in the near future
+# - _14 I will stick with my current system until it needs replacing
+# - _15 I don't think it makes financial sense as an investment
+# - _977 Don't know
+# - _944 Not applicable - There is no specific barrier towards installing a heat pump in my home
+#
+
+# %%
+# Modify full question labels in lookup
+pen_q11_options = [option for option in code_question_lookup.keys() if "Q11_" in option]
+for option in pen_q11_options:
+    code_question_lookup[option] = (
+        """Which, if any, of the following factors do you think would prevent you from installing a heat pump in your home? (Please select all that apply. If there is no specific barrier towards installing a heat pump in your home, please select the "Not applicable" option): """
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean and replace NaN
+for option in pen_q11_options:
+    data[option] = data[option].map({"Yes": "True", "No": "False"})
+    data[option] = data[option].fillna("Not asked")
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data, pen_q11_options, "PEN_Q11_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["PEN_Q11_collapsed"] = (
+    """Which, if any, of the following factors do you think would prevent you from installing a heat pump in your home? (Please select all that apply. If there is no specific barrier towards installing a heat pump in your home, please select the "Not applicable" option)"""
+)
+
+# %% [markdown]
+# #### Which ONE of the following factors do you think would prevent you the MOST from installing a heat pump in your home?
+# Respondents asked to choose one option from PEN_Q11 if selected more than one.
+# - Response type: Text strings
+# - Number of NA: 207 - only asked those who do not own a heat pump (did not select Heat pump in Q2) AND are homeowners (selected one of the "Own" options in profile_house_tenure)
+# - Cleaning:
+#     - Replace NaN with "Not asked"
+#     - Convert to categorical
+
+# %%
+data["PEN_Q12"] = data["PEN_Q12"].fillna("Not asked")
+
+# %%
+data["PEN_Q12"] = pd.Categorical(
+    data["PEN_Q12"],
+    categories=[
+        "Too expensive to install",
+        "Not convinced that the technology is good enough to heat my home",
+        "Wouldn't be appropriate for my property",
+        "I worry I may end up paying more for my energy bills",
+        "Difficulty finding a trader I trust to install it",
+        "I don't have enough information to make an informed decision",
+        "Too much hassle to research and find an installer",
+        "Too much disruption to my home",
+        "Planning permission",
+        "I'm not the decision-maker about energy in my household",
+        "Others in my household would need to be convinced",
+        "I am happy with my current heating system and don't see any reason to change it",
+        "I am planning to move home in the near future",
+        "I will stick with my current system until it needs replacing",
+        "I don't think it makes financial sense as an investment",
+        "Don't know",
+        "Not applicable - There is no specific barrier towards installing a heat pump in my home",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q12")
+
+# %% [markdown]
+# #### PEN_Q13. Which, if any, of the following benefits about heat pumps is likely to encourage you to install a heat pump in your home in the future? (Please select all that apply. If you would never get a heat pump installed in your home, please select the "Not applicable" option)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 207 - only asked those who do not own a heat pump (did not select Heat pump in Q2) AND are homeowners (selected one of the "Own" options in profile_house_tenure)
+#     - Cleaning:
+#         - Convert "Yes"/"False" to "True"/"False" (string)
+#         - Replace NaN with "Not asked" (string)
+#
+# - _1 It can help lower household energy bills
+# - _2 It's more environmentally friendly and sustainable than traditional heating systems
+# - _3 To future proof my home as it will be one of the main ways people heat their home in the future
+# - _4 It has a long lifespan and needs little maintenance
+# - _5 It would heat my home better/more reliably than my current system
+# - _6 Independence from gas/oil/solid fuel
+# - _7 Other people I know are doing it and I don't want to get left behind
+# - _8 To use the electricity  generated by solar panels
+# - _977 Don't know
+# - _944 Not applicable - I would never get a heat pump installed in my home
+
+# %%
+# Modify full question labels in lookup
+pen_q13_options = [option for option in code_question_lookup.keys() if "Q13_" in option]
+for option in pen_q13_options:
+    code_question_lookup[option] = (
+        'Which, if any, of the following benefits about heat pumps is likely to encourage you to install a heat pump in your home in the future? (Please select all that apply. If you would never get a heat pump installed in your home, please select the "Not applicable" option): '
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+for option in pen_q13_options:
+    data[option] = data[option].map({"Yes": "True", "No": "False"})
+    data[option] = data[option].fillna("Not asked")
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data, pen_q13_options, "PEN_Q13_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["PEN_Q13_collapsed"] = (
+    """Which, if any, of the following benefits about heat pumps is likely to encourage you to install a heat pump in your home in the future? (Please select all that apply. If you would never get a heat pump installed in your home, please select the "Not applicable" option)"""
+)
+
+# %% [markdown]
+# #### Which ONE of the following benefits about heat pumps is MOST likely to encourage you to install a heat pump in your home in the future?
+# Respondents asked to choose one option from PEN_Q13 if selected more than one.
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 207 - only asked those who do not own a heat pump (did not select Heat pump in Q2) AND are homeowners (selected one of the "Own" options in profile_house_tenure)
+#     - Cleaning:
+#         - Replace NaN with "Not asked"
+#         - Convert to categorical
+
+# %%
+data["PEN_Q14"] = data["PEN_Q14"].fillna("Not asked")
+
+# %%
+data["PEN_Q14"] = pd.Categorical(
+    data["PEN_Q14"],
+    categories=[
+        "It can help lower household energy bills",
+        "It's more environmentally friendly and sustainable than traditional heating systems",
+        "To future proof my home as it will be one of the main ways people heat their home in the future",
+        "It has a long lifespan and needs little maintenance",
+        "It would heat my home better/more reliably than my current system",
+        "Independence from gas/oil/solid fuel",
+        "Other people I know are doing it and I don't want to get left behind",
+        "To use the electricity  generated by solar panels",
+        "Don't know",
+        "Not applicable - I would never get a heat pump installed in my home",
+        "Not asked",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q14")
+
+# %% [markdown]
+# ### PEN_Q15. For the following question, please imagine that you find out that your boiler will stop working in a year...  Which, if any, of the following sources would you consult in order to figure out what you should do? (Please select all that apply. If you would not consult any sources, please select the 'Not applicable' option)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 3249 - Homeowners AND have a mains gas/tank or bottled gas as main type of central heating not asked
+#     - Cleaning:
+#         - Convert all open responses to string
+#         - Replace NaN to "Not asked" (string)
+#         - Convert to "Yes"/"No" to "True"/"False" (string)
+#         - Recode "Other" free text responses that should be classified in one of the given types
+#
+# - _1 Household members
+# - _2 Wider family
+# - _3 Friends
+# - _4 Boiler engineer
+# - _5 Social media
+# - _6 Energy company
+# - _7 Internet searches
+# - _8 AI/ ChatGPT
+# - _955 Other
+# - _977 Don't know
+# - _944 Not applicable - I would not consult any sources
+# - _open1 Which, if any, of the following sources would you consult in order to figure out what you should do? -Other
+
+# %%
+# Modify full question labels in lookup
+pen_q15_options = [option for option in code_question_lookup.keys() if "Q15_" in option]
+for option in pen_q15_options:
+    code_question_lookup[option] = (
+        "For the following question, please imagine that you find out that your boiler will stop working in a year...  Which, if any, of the following sources would you consult in order to figure out what you should do? (Please select all that apply. If you would not consult any sources, please select the 'Not applicable' option): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean and replace NaN
+for option in pen_q15_options:
+    data[option] = data[option].map(str)
+    if option != "PEN_Q15_open1":
+        data[option] = data[option].map({"Yes": "True", "No": "False"})
+        data[option] = data[option].fillna("Not asked")
+
+# %%
+## Recoding free text responses
+
+# Create recoded versions of each column
+for option in pen_q15_options:
+    if option != "PEN_Q15_open1":
+        data[f"{option}_recoded"] = data[option].copy()
+
+# %%
+# Indices of responses that selected "Other" in addition to one of the specified options
+other_plus_q15_indices = data.index[
+    (data["PEN_Q15_955"] == "True")
+    & (
+        (data["PEN_Q15_1"] == "True")
+        | (data["PEN_Q15_2"] == "True")
+        | (data["PEN_Q15_3"] == "True")
+        | (data["PEN_Q15_4"] == "True")
+        | (data["PEN_Q15_5"] == "True")
+        | (data["PEN_Q15_6"] == "True")
+        | (data["PEN_Q15_7"] == "True")
+        | (data["PEN_Q15_8"] == "True")
+        | (data["PEN_Q15_977"] == "True")
+        | (data["PEN_Q15_944"] == "True")
+    )
+]
+
+# %%
+# There are 5 responses to inspect
+data["PEN_Q15_open1"].value_counts()
+
+# %%
+## Invalid free text responses (NEW)
+invalid_responses_q15 = [
+    "Ok",
+]
+invalid_responses_q15_indices = data[
+    data["PEN_Q15_open1"].isin(invalid_responses_q15)
+].index
+
+# Create a new column for invalid responses
+data["PEN_Q15_invalid_recoded"] = data["PEN_Q15_955"].apply(
+    lambda x: x if x == "Not asked" else "False"
+)
+
+# If an invalid free response is given but a given option was selected, change their "Other" response to False
+for i in invalid_responses_q15_indices:
+    if i in other_plus_q15_indices:
+        data.loc[i, "PEN_Q15_955_recoded"] = "False"
+
+# If an invalid free response is given and no other option was selected, change their "Other" response to False and add an "Invalid response" column with "True"
+for i in invalid_responses_q15_indices:
+    if i not in other_plus_q15_indices:
+        data.loc[i, "PEN_Q15_955_recoded"] = "False"
+        data.loc[i, "PEN_Q15_invalid_recoded"] = "True"
+
+# %%
+## Should be "Wider family"
+wider_family_responses_q15 = ["My dad"]
+wider_family_responses_q15_indices = data[
+    data["PEN_Q15_open1"].isin(wider_family_responses_q15)
+].index
+
+# Change "Other" option to False and ensure/change "Wider family" to True
+for i in wider_family_responses_q15_indices:
+    data.loc[i, "PEN_Q15_955_recoded"] = "False"
+    data.loc[i, "PEN_Q15_2_recoded"] = "True"  # Wider family
+
+# %%
+# Update question lookup for new recoded columns
+for option in pen_q15_options:
+    if option != "PEN_Q15_open1":
+        recoded_col = f"{option}_recoded"
+        code_question_lookup[recoded_col] = code_question_lookup.get(option)
+
+code_question_lookup["PEN_Q15_invalid_recoded"] = (
+    """For the following question, please imagine that you find out that your boiler will stop working in a year...  Which, if any, of the following sources would you consult in order to figure out what you should do? (Please select all that apply. If you would not consult any sources, please select the 'Not applicable' option): Invalid response"""
+)
+
+# %%
+## Collapse all responses into a single column
+recoded_q15_options = [
+    option
+    for option in code_question_lookup.keys()
+    if "PEN_Q15_" in option and "recoded" in option
+]
+q15_options_to_collapse = [
+    option for option in recoded_q15_options if "open1" not in option
+]
+data = cleaning.collapse_select_all(
+    data, q15_options_to_collapse, "PEN_Q15_recoded_collapsed", code_question_lookup
+)
+
+# Update question lookup for new collapsed recoded column
+code_question_lookup["PEN_Q15_recoded_collapsed"] = (
+    """For the following question, please imagine that you find out that your boiler will stop working in a year...  Which, if any, of the following sources would you consult in order to figure out what you should do? (Please select all that apply. If you would not consult any sources, please select the 'Not applicable' option)"""
+)
+
+# %%
+# Check changes from recoding for each option
+q15_col_pairs = {}
+for option in pen_q15_options:
+    if option != "PEN_Q15_open1":
+        q15_col_pairs[option] = f"{option}_recoded"
+
+q15_col_pairs["PEN_Q15_invalid"] = "PEN_Q15_invalid_recoded"
+
+
+count_comparison = {}
+for original_col, recoded_col in q15_col_pairs.items():
+
+    if original_col in data.columns and recoded_col in data.columns:
+        counts_original = data[original_col].value_counts()
+        counts_recoded = data[recoded_col].value_counts()
+        count_comparison[recoded_col] = {
+            "Original True": counts_original.get("True", 0),
+            "Recoded True": counts_recoded.get("True", 0),
+            "Original False": counts_original.get("False", 0),
+            "Recoded False": counts_recoded.get("False", 0),
+        }
+    elif original_col not in data.columns:
+        counts_recoded = data[recoded_col].value_counts()
+        count_comparison[recoded_col] = {
+            "Original True": 0,
+            "Recoded True": counts_recoded.get("True", 0),
+            "Original False": 0,
+            "Recoded False": counts_recoded.get("False", 0),
+        }
+
+count_comparison_df = pd.DataFrame(count_comparison).T
+count_comparison_df
+
+# %% [markdown]
+# #### PEN_Q10new. Which, if any, of the following have you ever had an online or in person quote/ estimate for? (Please select all that apply)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 0
+#     - Cleaning:
+#         - Convert to boolean
+#
+# - _1 Heat pump
+# - _2 Solar panels
+# - _3 EV charger
+# - _966 None of these
+# - _977 Don't know/can't recall
+#
+
+# %%
+# Modify full question labels in lookup
+pen_q10_options = [
+    option for option in code_question_lookup.keys() if "Q10new_" in option
+]
+for option in pen_q10_options:
+    code_question_lookup[option] = (
+        "Which, if any, of the following have you ever had an online or in person quote/ estimate for? (Please select all that apply): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+for option in pen_q10_options:
+    data[option] = data[option].map({"Yes": True, "No": False}).astype(bool)
+
+# %%
+# Collapse to single column
+data = cleaning.collapse_select_all(
+    data, pen_q10_options, "PEN_Q10new_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["PEN_Q10new_collapsed"] = (
+    "Which, if any, of the following have you ever had an online or in person quote/ estimate for? (Please select all that apply)"
+)
+
+# %%
+summary_rows = []
+for col in pen_q10_options:
+    temp = (
+        pd.Series(pd.Categorical(data[col], [True, False]), name=col)
+        .to_frame()
+        .assign(weight=data["weight"])
+    )
+
+    summary_rows.append(
+        summary.create_single_question_summary_frame(temp, col)
+        .reset_index()
+        .melt(id_vars="index")
+        .assign(
+            column=lambda df: df["index"].astype(str).str.cat(df["variable"], sep="_")
+        )
+        .loc[:, ["column", "value"]]
+        .set_index("column")
+        .T.reset_index(drop=True)
+        .rename_axis(None, axis=1)
+        .rename(index={0: col})
+    )
+
+q10_counts_df = pd.concat(summary_rows)
+q10_counts_df
+
+# %% [markdown]
+# #### On a different topic...  Which ONE of the following statements BEST describes your feelings towards new technologies?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["PEN_Q19"] = pd.Categorical(
+    data["PEN_Q19"],
+    categories=[
+        "I often try new technology",
+        "I am open to trying new technology but I don't rush into it",
+        "I am concerned about trying new technology",
+        "Other",
+        "Don't know",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q19")
+
+# %% [markdown]
+# Open responses to PEN_Q19
+# - Response type: Text strings and integers
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to string
+
+# %%
+# Free text responses (144 unique responses)
+data["PEN_Q19_open1"] = data["PEN_Q19_open1"].map(str)
+
+# %% [markdown]
+# #### PEN_Q20. We would now like to understand how you've used loans and financing previously...  Which, if any, of the following have you ever taken out a loan to pay for, or paid in instalments? (Please select all that apply)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 0
+#     - Cleaning:
+#         - Convert to boolean
+#
+# - _1 A mortgage
+# - _2 A car
+# - _3 Kitchen improvements
+# - _4 Bathroom improvements
+# - _5 Smaller purchases (such as clothes or phones)
+# - _6 Home energy improvements excluding heat pumps (such as insulation, new windows, or solar panels)
+# - _7 A heat pump
+# - _8 Home extensions
+# - _966 None of these
+# - _977 Don't know/can't recall
+#
+
+# %%
+# Modify full question labels in lookup
+pen_q20_options = [option for option in code_question_lookup.keys() if "Q20_" in option]
+for option in pen_q20_options:
+    code_question_lookup[option] = (
+        "We would now like to understand how you've used loans and financing previously...  Which, if any, of the following have you ever taken out a loan to pay for, or paid in instalments? (Please select all that apply): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+for option in pen_q20_options:
+    data[option] = data[option].map({"Yes": True, "No": False}).astype(bool)
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data, pen_q20_options, "PEN_Q20_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["PEN_Q20_collapsed"] = (
+    "We would now like to understand how you've used loans and financing previously...  Which, if any, of the following have you ever taken out a loan to pay for, or paid in instalments? (Please select all that apply)"
+)
+
+# %% [markdown]
+# #### PEN_Q21. Thinking about the future...  For which, if any, of the following do you think you will ever take out a loan to pay or pay any of the following in instalments? (Please select all that apply)
+# - For all columns
+#     - Response type: Text strings
+#     - Number of NA: 0
+#     - Cleaning:
+#         - Convert to boolean
+#
+# - _1 A mortgage
+# - _2 A car
+# - _3 Kitchen improvements
+# - _4 Bathroom improvements
+# - _5 Smaller purchases (such as clothes or phones)
+# - _6 Home energy improvements excluding heat pumps (such as insulation, new windows, or solar panels)
+# - _7 A heat pump
+# - _8 Home extensions
+# - _966 None of these
+# - _977 Don't know/can't recall
+#
+
+# %%
+# Modify full question labels in lookup
+pen_q21_options = [option for option in code_question_lookup.keys() if "Q21_" in option]
+for option in pen_q21_options:
+    code_question_lookup[option] = (
+        "Thinking about the future...  For which, if any, of the following do you think you will ever take out a loan to pay or pay any of the following in instalments? (Please select all that apply): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+for option in pen_q21_options:
+    data[option] = data[option].map({"Yes": True, "No": False}).astype(bool)
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data, pen_q21_options, "PEN_Q21_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["PEN_Q21_collapsed"] = (
+    "Thinking about the future...  For which, if any, of the following do you think you will ever take out a loan to pay or pay any of the following in instalments? (Please select all that apply)"
+)
+
+# %% [markdown]
+# #### How desirable, if at all, would buying a house that has a heat pump be for you?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["PEN_Q5Dnew"] = pd.Categorical(
+    data["PEN_Q5Dnew"],
+    categories=[
+        "Very desirable",
+        "Somewhat desirable",
+        "Not very desirable",
+        "Not at all desirable",
+        "Don't know",
+    ],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "PEN_Q5Dnew")
+
+# %% [markdown]
+# #### Are you be willing to share your postcode with Experian for these purposes?
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to boolean
+
+# %%
+data["Q_consent"] = data["Q_consent"].map(
+    {
+        "Yes I am happy to share this information": True,
+        "No, I do not wish to share this information": False,
+    }
+)
+
+# %% [markdown]
+# #### Thanks for agreeing to share this information.Please provide your Postcode in the box below.
+# - Response type: Text strings
+# - Number of NA: 0
+# - Number of blanks (""): 1768 (those who did not give consent)
+# - Cleaning:
+#     - Convert to string type
+#     - Convert blanks to "Not asked"
+#     - Convert non-postcode responses to "Invalid response"
+#     - Convert all postcode letter characters to uppercase
+#     - Remove all spaces
+
+# %%
+data["Consent_1"] = data["Consent_1"].astype(str)
+
+# %%
+data["Consent_1"].head()
+
+# %%
+# Handling blanks
+data["Consent_1"] = data["Consent_1"].replace(to_replace="", value="Did not consent")
+
+# %%
+# Identifying and handling invalid responses
+# Include partial postcodes
+# Invalid criteria: Does not start with a letter OR Does not contain a number in the first four characters
+
+invalid_postcode_indices = data[
+    ~data["Consent_1"].str.match(r"^[A-Za-z]", na=False)  # does not start with letter
+    | ~data["Consent_1"]
+    .str[:4]
+    .str.contains(r"\d", na=False)  # does not contain number in first 4 chars
+].index
+
+# Remove "Did not consent"
+not_asked_indices = data[data["Consent_1"] == "Did not consent"].index
+invalid_postcode_indices = [
+    item for item in invalid_postcode_indices if item not in not_asked_indices
+]
+
+# Create a new recoded column
+data["Consent_1_recoded"] = data["Consent_1"]
+
+for i in invalid_postcode_indices:
+    data.loc[i, "Consent_1_recoded"] = "Invalid response"
+
+# %%
+# Verify all are invalid postcodes
+for i in invalid_postcode_indices:
+    print(data["Consent_1"][i])
+
+# %%
+# For valid postcodes: Remove space and change to all uppercase
+data["Consent_1_recoded"] = data["Consent_1_recoded"].apply(
+    lambda x: (
+        x.replace(" ", "").upper()
+        if x not in ["Did not consent", "Invalid response"]
+        else x
+    )
+)
+
+# %% [markdown]
+# #### Are you...? (gender)
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["profile_gender"] = pd.Categorical(
+    data["profile_gender"],
+    categories=["Male", "Female"],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_gender")
+
+# %% [markdown]
+# #### Age
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["profile_julesage"] = pd.Categorical(
+    data["profile_julesage"],
+    categories=["18-24", "25-34", "35-44", "45-54", "55+"],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_julesage")
+
+# %% [markdown]
+# #### Social grade
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to categorical
+
+# %%
+data["profile_socialgrade_cie_rc"] = pd.Categorical(
+    data["profile_socialgrade_cie_rc"],
+    categories=["ABC1", "C2DE"],
+    ordered=True,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_socialgrade_cie_rc")
+
+# %% [markdown]
+# #### Region
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - N/A
+
+# %%
+data["gornewUK"].value_counts(dropna=False)
+
+# %% [markdown]
+# #### Working status
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to boolean
+#
+# - _1 Working full time
+# - _2 Working part time
+# - _3 ALL WORKERS (NET)
+# - _4 Full time student
+# - _5 Retired
+# - _6 Unemployed
+# - _7 Not working/ Other
+
+# %%
+work_stat_options = [
+    option for option in code_question_lookup.keys() if "profile_work_stat_r_" in option
+]
+
+# Modify full question labels in lookup
+for option in work_stat_options:
+    code_question_lookup[option] = "Working Status: " + code_question_lookup.get(option)
+
+# %%
+# Convert to boolean
+for option in work_stat_options:
+    data[option] = data[option].map(
+        {
+            "Yes": True,
+            "No": False,
+        }
+    )
+
+# %% [markdown]
+# #### Marital status
+# - Response type: Text strings
+# - Number of NA: 1 (Cannot identify whether they whether these were not asked based on a condition, or whether they were asked and did not give any answer)
+# - Cleaning:
+#     - Keep NaN as empty
+#     - Convert to categorical
+
+# %%
+data["profile_marital_stat_r"] = pd.Categorical(
+    data["profile_marital_stat_r"],
+    categories=[
+        "Married/ Civil Partnership",
+        "Living as married",
+        "Separated/ Divorced",
+        "Widowed",
+        "Never Married",
+    ],
+    ordered=False,
+)
+
+# %%
+summary.create_single_question_summary_frame(data, "profile_marital_stat_r")
+
+# %% [markdown]
+# #### Children in Household
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to boolean
+#
+# - _1 0
+# - _2 1
+# - _3 2
+# - _4 3+
+# - _5 ALL WITH CHILDREN IN HOUSEHOLD (NET)
+# - _6 Refused
+
+# %%
+children_options = [
+    option
+    for option in code_question_lookup.keys()
+    if "profile_household_children_r_" in option
+]
+
+# Modify full question labels in lookup
+for option in children_options:
+    code_question_lookup[option] = "Children in Household: " + code_question_lookup.get(
+        option
+    )
+
+# %%
+# Convert to boolean
+for option in children_options:
+    data[option] = data[option].map(
+        {
+            "Yes": True,
+            "No": False,
+        }
+    )
+
+# %% [markdown]
+# #### Parent/Guardian
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning
+#     - Convert to boolean
+#
+# - _1 Parent/ guardian (any age)
+# - _2 Not parent/ guardian
+# - _3 4 years and under
+# - _4 5 to 11 years
+# - _5 12 to 16 years
+# - _6 17 to 18 years
+# - _7 18 years and under
+# - _8 Over 18 years
+
+# %%
+parent_options = [
+    option for option in code_question_lookup.keys() if "omnibus_parents_rc3_" in option
+]
+
+# Modify full question labels in lookup
+for option in parent_options:
+    code_question_lookup[option] = "Parent/Guardian: " + code_question_lookup.get(
+        option
+    )
+
+# %%
+# Convert to boolean
+for option in parent_options:
+    data[option] = data[option].map({"Yes": True, "No": False})
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data, parent_options, "omnibus_parents_rc3_collapsed", code_question_lookup
+)
+
+# Update question lookup
+code_question_lookup["omnibus_parents_rc3_collapsed"] = "Parent/Guardian"
+
+# %% [markdown]
+# #### Social Media/ Messaging service (within the last month)
+# - Response type: Text strings
+# - Number of NA: 35 (Cannot identify whether they whether these were not asked based on a condition, or whether they were asked and did not give any answer)
+# - Cleaning:
+#     - Keep NaN as empty
+#     - Convert "Yes"/"No" to "True"/"False" (string)
+#
+# - _1 Facebook
+# - _2 X
+# - _3 LinkedIn
+# - _4 Pinterest
+# - _5 Instagram
+# - _6 Snapchat
+# - _7 TikTok
+# - _8 Facebook Messenger
+# - _9 WhatsApp
+# - _10 Skype
+
+# %%
+social_media_options = [
+    option
+    for option in code_question_lookup.keys()
+    if "social_media_messaging_rc_" in option
+]
+
+# Modify full question labels in lookup
+for option in social_media_options:
+    code_question_lookup[option] = (
+        "Social Media/ Messaging service (within the last month): "
+        + code_question_lookup.get(option)
+    )
+
+# %%
+# Convert to boolean
+for option in social_media_options:
+    data[option] = data[option].map(
+        {
+            "Yes": "True",
+            "No": "False",
+        }
+    )
+
+# %%
+# Collapse options to a single column
+data = cleaning.collapse_select_all(
+    data,
+    social_media_options,
+    "social_media_messaging_rc_collapsed",
+    code_question_lookup,
+)
+
+# Update question lookup
+code_question_lookup["social_media_messaging_rc_collapsed"] = (
+    "Social Media/ Messaging service (within the last month)"
+)
+
+# %% [markdown]
+# #### [Keep criteria]
+# Note: These are used by YouGov to determine which responses to include.
+#
+# - Response type: Text strings
+# - Number of NA: 0
+# - Cleaning:
+#     - Convert to boolean
+#
+# - _0 keep (All below must be True)
+# - _1 profilesocialgradeciewtrc not empty
+# - _2 profileeducationlevelrecode not empty
+# - _3 profileworkstatr not empty
+# - _4 profilehouseholdchildrenr not empty
+# - _5 profileworktype not empty
+# - _6 omnibusparentsrc3 not empty
+# - _7 age >= 18 & profilejulesage not empty
+# - _8 age >= 18 & profilebpcagesex not empty
+# - _9 age >= 18
+
+# %%
+keep_options = [
+    option for option in code_question_lookup.keys() if "UK18_Sept_2020_f_" in option
+]
+
+# Modify full question labels in lookup
+for option in keep_options:
+    code_question_lookup[option] = "Keep criteria: " + code_question_lookup.get(option)
+
+# %%
+# Convert to boolean
+for option in keep_options:
+    data[option] = data[option].map(
+        {
+            "Yes": True,
+            "No": False,
+        }
+    )
+
+# %% [markdown]
+# ### Save cleaned data to parquet file
+
+# %%
+# Check final info
+data.info()
+
+# %%
+cleaned_data_path = f"""/mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2. Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov survey data/Analysis ready data/{datetime.now().strftime("%Y%m%d")}_yougov_survey_clean_data_wales_boost.parquet"""
+
+# %%
+data.to_parquet(cleaned_data_path)

--- a/asf_next_three_million_heat_pump_owners/notebooks/oil_users.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/oil_users.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_next_three_million_heat_pump_owners
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ### Analysis on attitudes of oil users
+# Date: 10/03/2026
+# Aim: Generate statistics for oil users to compare with Segment D
+
+# %%
+import pandas as pd
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.getters import load_data
+
+# %%
+# Load cleaned data
+data, wales_data = load_data.get_analysis_ready_data()
+
+# %%
+# Recode Q5 to change responses of those that actually do have a heat pump from Not asked to Already have a heat pump
+full_sample_data = data.copy(deep=True)
+full_sample_data["PEN_Q5_recoded"] = full_sample_data.apply(
+    lambda row: (
+        "Already have a heat pump" if row["PEN_Q2_3_recoded"] == True else row["PEN_Q5"]
+    ),
+    axis=1,
+)
+
+# %%
+# subset oil users
+oil_group = full_sample_data[full_sample_data["PEN_Q2_5_recoded"] == True]
+
+# %%
+print(
+    f"Number of respondents that heat with oil (weighted): {oil_group.groupby('PEN_Q2_5_recoded')['weight'].sum().round().iloc[0]}"
+)
+
+# %% [markdown]
+# Distrust in the technology's performance Segment D exhibits a high level of distrust in heat pump technology. When surveyed, 45% of this group stated they are "not convinced that the technology is good enough to heat my home"
+#
+# PEN_Q11_2:
+#     'Which, if any, of the following factors do you think would prevent you
+#     from installing a heat pump in your home? (Please select all that apply. If there
+#     is no specific barrier towards installing a heat pump in your home, please select
+#     the "Not applicable" option): Not convinced that the technology is good enough
+#     to heat my home'
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q11_2"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+filtered.groupby("PEN_Q11_2")["weight"].sum()
+
+# %%
+filtered.groupby("PEN_Q11_2")["weight"].sum().sum()
+
+# %%
+filtered.groupby("PEN_Q11_2")["weight"].sum() / filtered["weight"].sum()
+
+# %% [markdown]
+# Concerns about property suitability Because Segment D typically lives in detached, rural properties, they often hold a strong belief that heat pumps are unsuited to their homes. Nearly a third (31%) cite "wouldn't be appropriate for my property" as a primary barrier to installation
+#
+# PEN_Q11_3:
+#     'Which, if any, of the following factors do you think would prevent you
+#     from installing a heat pump in your home? (Please select all that apply. If there
+#     is no specific barrier towards installing a heat pump in your home, please select
+#     the "Not applicable" option): Wouldn''t be appropriate for my property'
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q11_3"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+filtered.groupby("PEN_Q11_3")["weight"].sum()
+
+# %%
+filtered.groupby("PEN_Q11_3")["weight"].sum().sum()
+
+# %%
+filtered.groupby("PEN_Q11_3")["weight"].sum() / filtered["weight"].sum()
+
+# %%
+summary.create_single_question_summary_frame(filtered, "house_type")
+
+# %% [markdown]
+# Satisfaction with their current system
+# - 47% say they will stick with their current system until it physically needs replacing.
+#
+# PEN_Q11_14:
+#     'Which, if any, of the following factors do you think would prevent
+#     you from installing a heat pump in your home? (Please select all that apply. If
+#     there is no specific barrier towards installing a heat pump in your home, please
+#     select the "Not applicable" option): I will stick with my current system until
+#     it needs replacing'
+#
+#
+# - 44% state they are happy with their current heating system and do not see any reason to change it.
+#
+# PEN_Q11_12:
+#     'Which, if any, of the following factors do you think would prevent
+#     you from installing a heat pump in your home? (Please select all that apply. If
+#     there is no specific barrier towards installing a heat pump in your home, please
+#     select the "Not applicable" option): I am happy with my current heating system
+#     and don''t see any reason to change it'
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q11_14"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+filtered.groupby("PEN_Q11_14")["weight"].sum()
+
+# %%
+filtered.groupby("PEN_Q11_14")["weight"].sum().sum()
+
+# %%
+filtered.groupby("PEN_Q11_14")["weight"].sum() / filtered["weight"].sum()
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q11_12"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+filtered.groupby("PEN_Q11_12")["weight"].sum()
+
+# %%
+filtered.groupby("PEN_Q11_12")["weight"].sum().sum()
+
+# %%
+filtered.groupby("PEN_Q11_12")["weight"].sum() / filtered["weight"].sum()
+
+# %% [markdown]
+# High upfront costs Cost remains a heavily cited deterrent, with participants noting that the "initial outlay is very costly". Interestingly, while the high upfront cost completely deters some from even looking into the technology, Segment D is actually slightly less likely than other groups to cite expense as their **primary barrier** (55% for Segment D compared to the 63% national average), likely because they generally have stable or higher incomes and own their homes outright.
+#
+# PEN_Q12:
+#     Which ONE of the following factors do you think would prevent you the MOST
+#     from installing a heat pump in your home?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q12"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q12")
+
+# %% [markdown]
+# Views on Subsidised Scenarios
+# When this segment is explicitly presented with a scenario outlining a £12,000 heat pump installation supported by a £7,500 grant, the financial aid does make it viable for some, but it does not overcome the barrier for the majority:
+# *   26% find it affordable: 7% consider this scenario "very affordable" and 19% consider it "fairly affordable"
+# *   68% find it unaffordable: Despite the £7,500 grant, 41% still rate this as "very unaffordable" and 27% rate it as "fairly unaffordable".
+#
+# PEN_Q5Anew:
+#     "Upgrading from a fossil fuel boiler to an air source heat pump can\
+#     \ cost \xA312,000 for a typical home. Often smaller, modern homes cost a bit less\
+#     \ and larger older homes a bit more. In England, Wales and Scotland, grants are\
+#     \ available of up to \xA37,500 to lo"
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q5Anew"] != "Not asked"
+]  # respondents already have heat pump, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q5Anew")
+
+# %% [markdown]
+# Extreme Reluctance to Finance or Borrow
+# Segment D is almost universally opposed to taking on debt to pay for a heat pump.
+# *   Unsecured Borrowing: They are highly resistant to using personal loans or credit cards to fund low-carbon heating, with 76% stating they are "not at all willing" and 16% "not very willing" to do so.
+# *   Mortgage Extensions: There is similarly high resistance to using secured debt. 69% are "not at all willing" to extend an existing mortgage or take out a new one for a heat pump. This specific reluctance is highly logical given their lifestage; 81% of this segment own their homes. and the vast majority (67%) have already paid off their mortgages entirely.
+# Ultimately, only 3% of this segment believe they would ever consider taking out a loan or paying in instalments specifically for a heat pump.
+#
+# PEN_Q5Bnew:
+#     How willing, if at all, would you be to borrow funds from a mortgage
+#     provider to fund the installation of low carbon heating (such as heat pumps) in
+#     your home? (This could involve extending your existing mortgage or taking out
+#     a small additional mortgage)
+#   PEN_Q5Cnew:
+#     How willing, if at all, would you be to take out unsecured borrowing
+#     (e.g. via a personal loan or credit card) in order to fund the installation of
+#     low carbon heating (such as heat pumps) in your home?
+
+# %%
+summary.create_single_question_summary_frame(oil_group, "profile_house_tenure")
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q5Bnew"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q5Bnew")
+
+# %%
+summary.create_single_question_summary_frame(filtered, "profile_house_tenure")
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q5Cnew"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q5Cnew")
+
+# %% [markdown]
+# *Additional*
+
+# %% [markdown]
+# PEN_Q4. Before taking this survey, had you ever heard of heat pumps as a home heating system? (Please select the option that best applies)
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q4"] != "Not asked"
+]  # respondents already have a heat pump, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q4")
+
+# %% [markdown]
+# PEN_Q5: How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q5"] != "Not asked"
+]  # respondents already have a heat pump, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q5")
+
+# %% [markdown]
+# PEN_Q6: Before taking this survey, have you ever seen what a heat pump looks like?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q6"] != "Not asked"
+]  # respondents who are aware of heat pumps
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q6")
+
+# %% [markdown]
+# PEN_Q7: Have you ever been to a home that has a heat pump?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q7"] != "Not asked"
+]  # respondents who are aware of heat pumps
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q7")
+
+# %% [markdown]
+# PEN_Q8: Does anyone in your family, close friends or neighbours own a heat pump?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q8"] != "Not asked"
+]  # respondents who are aware of heat pumps
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q8")
+
+# %% [markdown]
+# PEN_Q9:
+#     Have you ever had a conversation with your family, close friends or neighbours
+#     about installing a heat pump in your home?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q9"] != "Not asked"
+]  # respondents who are aware of heat pumps
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q9")

--- a/asf_next_three_million_heat_pump_owners/notebooks/oil_users.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/oil_users.py
@@ -294,3 +294,18 @@ filtered = oil_group[
 
 # %%
 summary.create_single_question_summary_frame(filtered, "PEN_Q9")
+
+# %% [markdown]
+# PEN_Q14:
+#     Which ONE of the following benefits about heat pumps is MOST likely to
+#     encourage you to install a heat pump in your home in the future?
+
+# %%
+filtered = oil_group[
+    oil_group["PEN_Q14"] != "Not asked"
+]  # respondents who are not homeowners, not asked
+
+# %%
+summary.create_single_question_summary_frame(filtered, "PEN_Q14")
+
+# %%

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_1_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_1_summary.py
@@ -1434,7 +1434,7 @@ else:
     )
 
 # %% [markdown]
-# ## Summarising the effects of prior knowledge/experiences
+# ## Summarising the association with prior knowledge/experiences
 
 # %% [markdown]
 # **Know what they are**
@@ -1442,31 +1442,31 @@ else:
 # - Have heard of but don't know what they are: 46% vs. 38%
 # - Never heard of: 35% vs. 31%
 #
-# *Knowing what they are does not lead to a greater likelihood of considering.*
+# *No observed association between knowing what a heat pump is and the likelihood of considering one.*
 #
 # **Have seen one**
 # - Seen: 42% vs. 53%
 # - Not seen: 47% vs. 39%
 #
-# *Having seen one does not lead to a greater likelihood of considering.*
+# *No observed association between having seen a heat pump and the likelihood of considering one.*
 #
 # **Been to a home with one**
 # - Been: 51% vs. 45%
 # - Not been: 41% vs. 50%
 #
-# *Having been to a home with a heat pump does lead to a greater likelihood of considering.*
+# *Association observed between having been to a home with a heat pump and the likelihood of considering.*
 #
 # **Family/friends/neighbours have one**
 # - Have: 58% vs. 40%
 # - Don't have: 41% vs. 51%
 #
-# *Having family/friends/neighbours with a heat pump does lead to a greater likelihood of considering.*
+# *Association observed between having family/friends/neighbours with a heat pump and the likelihood of considering.*
 #
 # **Have had a conversation about installing one**
 # - Have: 57% vs. 40%
 # - Haven't: 41% vs. 48%
 #
-# *Having a conversation with family/friends/neighbours about installing a heat pump does lead to a greater likelihood of considering.*
+# *Association observed between having had a conversation with family/friends/neighbours about installing a heat pump and the likelihood of considering.*
 #
 
 # %% [markdown]

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_1_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_1_summary.py
@@ -1,0 +1,1848 @@
+# -*- coding: utf-8 -*-
+# ---
+# title: "RQ 1. How likely are UK households to consider installing a heat pump?"
+# format:
+#   revealjs:
+#     scrollable: true
+#     smaller: true
+#     embed-resources: true
+#     css: styles.css
+#     slide-number: true
+#     footer: "RQ 1. How likely are UK households to consider installing a heat pump?"
+# execute:
+#   enabled: true
+#   echo: false
+#   output: true
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_next_three_million_heat_pump_owners
+#     language: python
+#     name: python3
+# ---
+
+# %%
+## Instructions for rendering
+# 1. Save as a separate .ipynb file
+# 2. Run: quarto render asf_next_three_million_heat_pump_owners/notebooks/[FILE_NAME].ipynb --to revealjs
+
+# %%
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm, chi2_contingency
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.getters import load_data
+
+# %%
+# Load cleaned data
+data, wales_data = load_data.get_analysis_ready_data()
+
+# Get code to full question look-up dictionary
+code_question_lookup = config.get("code_question_lookup")
+
+# %% [markdown]
+# ## Question that respondents were asked (PEN_Q5)
+#
+# For the following questions, please imagine that in the next 5 years...(i.e. from now till February 2030), you want to install a central heating system for your home/ your current heating system needs replacing…
+# A heat pump can heat a home. An outside unit (see picture) takes heat from the air, concentrates it, and puts it into radiators.
+# It's like a fridge in reverse. It works effectively in all weather conditions, including on cold days.
+# Heat pumps run on electricity so differ to boilers, which run on fossil fuels (gas or oil).
+# This means that heat pumps can run using electricity that is generated from renewable resources, such as wind or sun, which do not produce carbon emissions…
+#
+# **How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?**
+#
+# (Please select the option that best applies. Even if you are not currently a homeowner, we are still interested in your opinion.)
+
+# %% [markdown]
+# ## Overview of all respondents (including those with a heat pump)
+
+# %%
+# Recode Q5 to change responses of those that actually do have a heat pump from Not asked to Already have a heat pump
+full_sample_data = data.copy(deep=True)
+full_sample_data["PEN_Q5_recoded"] = full_sample_data.apply(
+    lambda row: (
+        "Already have a heat pump" if row["PEN_Q2_3_recoded"] == True else row["PEN_Q5"]
+    ),
+    axis=1,
+)
+
+# %% [markdown]
+# 2% of all respondents have a heat pump. This is similar to the percentages reported in the [Which? Sustainability Tracker 2024](https://www.which.co.uk/policy-and-insight/article/whichs-annual-sustainability-report-series-2024-home-insulation-and-heating-a0S066z6SiHV#chapter-2-the-home-heating-challenge) and the most recent [DESNZ Public Attitudes Tracker](https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-winter-2024/desnz-public-attitudes-tracker-heat-and-energy-use-in-the-home-winter-2024-uk#low-carbon-heating-systems), but they report only for homeowners or owner occupiers.
+
+# %%
+q5_full_df = (
+    full_sample_data.groupby("PEN_Q5_recoded", dropna=False)["weight"]
+    .sum()
+    .reset_index()
+    .rename(columns={"weight": "weighted Count", "PEN_Q5_recoded": "Value"})
+)
+
+
+q5_full_df.columns = ["How likely to consider", "weighted count"]
+q5_full_df["weighted percentage"] = (
+    q5_full_df["weighted count"] / q5_full_df["weighted count"].sum()
+) * 100
+
+# Formatting output
+q5_full_df.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).format(
+    {
+        "weighted count": "{:.0f}",
+        "weighted percentage": "{:.1f}",
+    }
+).set_caption(
+    "How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?"
+)
+
+# %% [markdown]
+# The following analysis focuses only on respondents that do not have a heat pump, who were asked PEN_Q5.
+#
+# - Respondents who said they had a heat pump were not asked (n = 135).
+# - From recoding free text responses, however, we identified three responses that indicated that the respondent has a heat pump. As these respondents should not have been asked, we have excluded them from the question base.
+# - Base (unweighted): 6,890
+# - Base (unweighted), after recoding: 6,887
+# - Base (weighted), after recoding: 6,875
+
+# %%
+q5_base_data = data[~(data["PEN_Q2_3_recoded"] == True)]
+
+# %%
+# n = 16 excluded from Wales dataset who have a heat pump
+q5_base_data_wales = wales_data[~(wales_data["PEN_Q2_3_recoded"] == True)]
+
+# %% [markdown]
+# ## RQ 1. Overall
+
+# %% [markdown]
+# Almost equal shares of people who don't already have a heat pump said they would (43%) and wouldn't (44%) consider installing a heat pump in their home as their main heating source, leaving 12% who said that they didn't know.
+
+# %%
+# Define response aggregation structure
+q5_response_aggregation_dict = {
+    "Would consider (net)": ["Probably would consider", "Definitely would consider"],
+    "Wouldn't consider (net)": [
+        "Probably wouldn't consider",
+        "Definitely wouldn't consider",
+    ],
+}
+
+# %%
+# Summary dataframe
+q5_uk = summary.create_single_question_summary_frame(q5_base_data, "PEN_Q5")
+
+# Rename columns
+q5_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q5_uk = q5_uk.drop(index="Not asked").dropna().round(1)
+
+# Combine categories
+for combined_col, source_cols in q5_response_aggregation_dict.items():
+    q5_uk.loc[combined_col, :] = q5_uk.loc[source_cols, :].sum()
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q5_base_data, "PEN_Q5", "weight") * 100
+q5_uk = q5_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Add confidence intervals for combined weighted proportions
+consider_net = summary.weighted_props_ci_combine_categories(
+    q5_uk,
+    "Definitely would consider",
+    "Probably would consider",
+    "Would consider (net)",
+)
+q5_uk.loc["Would consider (net)", "Lower CI"] = consider_net["Lower CI"]
+q5_uk.loc["Would consider (net)", "Upper CI"] = consider_net["Upper CI"]
+q5_uk.loc["Would consider (net)", "SE"] = consider_net["SE"]
+
+not_consider_net = summary.weighted_props_ci_combine_categories(
+    q5_uk,
+    "Definitely wouldn't consider",
+    "Probably wouldn't consider",
+    "Wouldn't consider (net)",
+)
+q5_uk.loc["Wouldn't consider (net)", "Lower CI"] = not_consider_net["Lower CI"]
+q5_uk.loc["Wouldn't consider (net)", "Upper CI"] = not_consider_net["Upper CI"]
+q5_uk.loc["Wouldn't consider (net)", "SE"] = not_consider_net["SE"]
+
+# %%
+# Format display
+q5_uk[
+    ["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]
+].style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).format(
+    {
+        "Weighted count": "{:.0f}",
+        "Weighted percentage": "{:.1f}",
+        "Lower CI": "{:.1f}",
+        "Upper CI": "{:.1f}",
+        "SE": "{:.1f}",
+    }
+).set_caption(
+    "How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source? (With lower and upper 95% confidence interval values for proportions)"
+)
+
+# %% [markdown]
+# ## RQ 1. By nation
+
+# %% [markdown]
+# The proportions of respondents who said they definitely/probably would consider are similar across E/S/W (~42%), with a slight variation where a lower proportion of people in Wales said they they would definitely consider and a higher proportion said they would probably consider.
+#
+# The proportions who said they definitely/probably wouldn't consider are similar across E/S/W (~45%), as well as those who said they didn't know.
+
+# %%
+# Individual nation datasets
+q5_base_data_england = q5_base_data[q5_base_data["gornewUK_6"] == True]
+# q5_base_data_wales = q5_base_data[q5_base_data["gornewUK_7"] == True]
+q5_base_data_scotland = q5_base_data[q5_base_data["gornewUK_8"] == True]
+q5_base_data_ni = q5_base_data[q5_base_data["gornewUK_9"] == True]
+
+# Dataset lookup dictionary
+q5_base_data_lookup = {
+    "uk": q5_base_data,
+    "england": q5_base_data_england,
+    "wales": q5_base_data_wales,
+    "scotland": q5_base_data_scotland,
+    "ni": q5_base_data_ni,
+}
+
+# Create comparison table for all nations and UK
+q5_nations_df, q5_nations_pct_df = summary.create_nations_summary_tables(
+    q5_base_data, q5_base_data_wales, "PEN_Q5", True
+)
+q5_nations_pct_df = q5_nations_pct_df.drop(["Northern Ireland", "UK"])
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q5_nations_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q5_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q5", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q5_nations_pct_df_ci = q5_nations_pct_df.copy(deep=True)
+
+q5_nations_pct_df_ci = q5_nations_pct_df_ci.astype(str)
+
+for index in q5_nations_pct_df_ci.index:
+    for response in q5_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q5_nations_pct_df_ci.loc[index, response] = (
+            f"""{q5_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+# Add sample sizes
+q5_nations_pct_df_ci = (
+    q5_nations_pct_df_ci.join(q5_nations_df["Nation total"])
+    .assign(n=lambda df: df["Nation total"].round(0).astype(int))
+    .drop(columns="Nation total")
+)
+
+# %%
+# Format display
+q5_nations_pct_df_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %% [markdown]
+# ## RQ 1. By tenure
+
+# %% [markdown]
+# The tenure group with the highest proportion of people who said they definitely/probably would consider is the "Neither" group (living with family/friends, or other) (49%), compared to 42% of homeowners and 44% of renters.
+#
+# The group with the highest proportion of people who said they definitely/probably wouldn't consider is the homeowner group (50%). This is notably higher than the percentages of renters and others (37% and 30%, respectively).
+#
+# Unsurprisingly, the "neither" tenure group had the highest percentage of people who said they didn't know (21%), compared to homeowners (8%) and renters (18%).
+#
+# The homeowners group is the only one where the proportion of those who wouldn't consider (50%) is greater than the proportion who said they would (42%).
+#
+
+# %%
+# Create Q5 response breakdown by tenure table for each nation
+q5_tenure_tables = {}
+for group, base_data in q5_base_data_lookup.items():
+    tables = {}
+    counts_by_tenure, proportions_by_tenure = summary.generate_tenure_breakdown(
+        base_data, "PEN_Q5", q5_response_aggregation_dict, proportions_axis=1
+    )
+    tables["counts"] = counts_by_tenure
+    tables["proportions"] = proportions_by_tenure
+
+    q5_tenure_tables[group] = tables
+
+# %%
+# Plot broad tenure categories comparison
+q5_tenure_pct_df = (
+    q5_tenure_tables["uk"]["proportions"]
+    .reindex(index=["Own (net)", "Rent (net)", "Neither (net)", "Other"])
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5_tenure_pct_df, "Percentage", "Tenure", 10, (10, 5)
+).show()
+
+# %%
+# Add 95% confidence intervals for proportions
+
+# Aggregated responses to profile_house_tenure
+aggregated_responses_tenure = {
+    "Own (net)": [
+        "Own - outright",
+        "Own - with a mortgage",
+        "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+    ],
+    "Rent (net)": [
+        "Rent - from a private landlord",
+        "Rent - from my local authority",
+        "Rent - from a housing association",
+    ],
+    "Neither (net)": [
+        "Neither - I live with my parents, family or friends but pay some rent to them",
+        "Neither - I live rent-free with my parents, family or friends",
+    ],
+}
+
+q5_tenure_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5_base_data,
+    proportions_df=q5_tenure_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_tenure,
+    index_survey_code="profile_house_tenure",
+).drop(columns="Total")
+
+# %%
+# Display broad tenure categories for UK, proportions with 95% CI
+q5_tenure_proportions_with_ci_summary = (
+    q5_tenure_proportions_with_ci.join(q5_tenure_tables["uk"]["counts"]["Total"])
+    .assign(n=lambda df: df["Total"].round(0).astype(int))
+    .drop(columns="Total")
+)
+
+# %%
+# Format display
+q5_tenure_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across tenure
+q5_tenure_counts_summary = q5_tenure_tables["uk"]["counts"].drop(
+    index=["Own (net)", "Rent (net)", "Neither (net)", "Total"],
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_tenure_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By tenure: Homeowners
+
+# %% [markdown]
+# People who own their home outright have the lowest proportion of people who would consider installing a heat pump (36%) and the greatest proportion who say they wouldn't (58%), compared to people who own their home with a mortgage (50% would, 42% wouldn't) or through part-ownership (46% would, 49% wouldn't).
+#
+# N.B. 49% of those who own their home outright are aged 55+ and said they definitely/probably wouldn't consider installing a heat pump.
+
+# %%
+# Plot homeowners only comparison table
+q5_tenure_homeowners_pct_df = (
+    q5_tenure_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "Own - outright",
+            "Own - with a mortgage",
+            "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+    .rename(
+        index={
+            "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)": "Own (part-own)"
+        }
+    )
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5_tenure_homeowners_pct_df, "Percentage", "Homeowner tenure subgroup", 10, (10, 5)
+).show()
+
+# %%
+# Display owner tenure categories for UK, proportions with 95% CI
+q5_homeowner_proportions_with_ci_summary = (
+    q5_tenure_proportions_with_ci.reindex(
+        [
+            "Own - outright",
+            "Own - with a mortgage",
+            "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+        ]
+    )
+    .join(q5_tenure_tables["uk"]["counts"]["Total"])
+    .assign(n=lambda df: df["Total"].round(0).astype(int))
+    .drop(columns="Total")
+)
+
+# %%
+q5_homeowner_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across owners tenures
+q5_homeowner_counts_summary = (
+    q5_tenure_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "Own - outright",
+            "Own - with a mortgage",
+            "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_homeowner_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %%
+# Run this cell to check age x tenure assertion
+# (
+#     pd.crosstab(
+#         index=[q5_base_data["PEN_Q5"], q5_base_data["profile_julesage"]],
+#         columns=q5_base_data["profile_house_tenure"],
+#         values=q5_base_data["weight"],
+#         aggfunc="sum",
+#         margins=True,
+#         normalize="columns",
+#     )
+#     * 100
+# ).round(1)
+
+# %% [markdown]
+# ## RQ 1. By tenure: Renters
+
+# %% [markdown]
+# The renter tenure group with the greatest proportion who said they would consider installing a heat pump is private renters (50%), compared to the groups of people renting social housing (36% for local authority rentals and 38% for housing association rentals).
+#
+# Private renters also have the smallest proportion of those who said they wouldn't consider (34%), around ~10 percentage points lower than the groups of people renting social housing (43% for local authority rentals and 41% for housing association rentals).
+
+# %%
+# Plot homeowners only comparison table
+q5_tenure_renters_pct_df = (
+    q5_tenure_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "Rent - from a private landlord",
+            "Rent - from my local authority",
+            "Rent - from a housing association",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5_tenure_renters_pct_df, "Percentage", "Renter tenure subgroup", 10, (10, 5)
+).show()
+
+# %%
+# Display renter tenure categories for UK, proportions with 95% CI
+q5_renter_proportions_with_ci_summary = (
+    q5_tenure_proportions_with_ci.reindex(
+        [
+            "Rent - from a private landlord",
+            "Rent - from my local authority",
+            "Rent - from a housing association",
+        ]
+    )
+    .join(q5_tenure_tables["uk"]["counts"]["Total"])
+    .assign(n=lambda df: df["Total"].round(0).astype(int))
+    .drop(columns="Total")
+)
+
+# %%
+q5_renter_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across renter tenures
+q5_renter_counts_summary = (
+    q5_tenure_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "Rent - from a private landlord",
+            "Rent - from my local authority",
+            "Rent - from a housing association",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_renter_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By tenure: Other
+
+# %% [markdown]
+# Approximately half of respondents who live with family/friends said they would consider installing a heat pump in their home (50%, 48% of those living with family/friends paying rent and those living rent-free, respectively).
+
+# %%
+# Plot neither/others comparison table
+q5_tenure_other_pct_df = (
+    q5_tenure_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "Neither - I live with my parents, family or friends but pay some rent to them",
+            "Neither - I live rent-free with my parents, family or friends",
+            "Other",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5_tenure_other_pct_df, "Percentage", "Other tenure subgroup", 10, (10, 5)
+).show()
+
+# %%
+# Display neither/other tenure categories for UK, proportions with 95% CI
+q5_other_proportions_with_ci_summary = (
+    q5_tenure_proportions_with_ci.reindex(
+        [
+            "Neither - I live with my parents, family or friends but pay some rent to them",
+            "Neither - I live rent-free with my parents, family or friends",
+            "Other",
+        ]
+    )
+    .join(q5_tenure_tables["uk"]["counts"]["Total"])
+    .assign(n=lambda df: df["Total"].round(0).astype(int))
+    .drop(columns="Total")
+)
+
+# %%
+q5_other_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across other/neither tenures
+q5_other_counts_summary = (
+    q5_tenure_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "Neither - I live with my parents, family or friends but pay some rent to them",
+            "Neither - I live rent-free with my parents, family or friends",
+            # "Other",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_other_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By household income (1)
+
+# %% [markdown]
+# The proportion of respondents who said "Don't know" decreases with increasing income brackets - i.e., the higher the household income, the more likely the respondent is to have an opinion or know whether they or wouldn't consider installing a heat pump.
+#
+# There is an association between income and the proportion who said they would consider. Greater shares of respondents of higher income brackets who said they would consider compared to lower brackets - e.g. 39% of those earning between £10,000 and £29,999 per year vs. 59% of those earning between £100,000 and £149,999 per year.
+#
+# There isn't, however, as clear a trend between income and the proportion who said they wouldn't consider.
+#
+
+# %%
+# Create Q5 response breakdown by tenure table for each nation
+q5_income_tables = {}
+for group, base_data in q5_base_data_lookup.items():
+    tables = {}
+    counts_by_income, proportions_by_income = summary.generate_income_breakdown(
+        base_data,
+        "PEN_Q5",
+        q5_response_aggregation_dict,
+        proportions_axis=1,
+        aggregate_income=True,
+    )
+    tables["counts"] = counts_by_income
+    tables["proportions"] = proportions_by_income
+
+    q5_income_tables[group] = tables
+
+# %%
+# Plot income bracket comparison table
+q5_income_pct_df = (
+    q5_income_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5_income_pct_df, "Percentage", "Income", 10, (10, 10)
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+
+# Aggregated responses to profile_gross_household
+aggregated_responses_income = {
+    "under £10,000 per year (net)": [
+        "under £5,000 per year",
+        "£5,000 to £9,999 per year",
+    ],
+    "£10,000 to £29,999 per year (net)": [
+        "£10,000 to £14,999 per year",
+        "£15,000 to £19,999 per year",
+        "£20,000 to £24,999 per year",
+        "£25,000 to £29,999 per year",
+    ],
+    "£30,000 to £49,999 per year (net)": [
+        "£30,000 to £34,999 per year",
+        "£35,000 to £39,999 per year",
+        "£40,000 to £44,999 per year",
+        "£45,000 to £49,999 per year",
+    ],
+    "£50,000 to £69,999 per year (net)": [
+        "£50,000 to £59,999 per year",
+        "£60,000 to £69,999 per year",
+    ],
+}
+
+q5_income_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5_base_data,
+    proportions_df=q5_income_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_income,
+    index_survey_code="profile_gross_household",
+).drop(columns="Total")
+
+# %%
+# Show only aggregated income brackets
+q5_income_proportions_with_ci_summary = (
+    q5_income_proportions_with_ci.reindex(
+        [
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .join(q5_income_tables["uk"]["counts"]["Total"].round(0))
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+# %%
+q5_income_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across income brackets (net)
+q5_income_counts_summary = (
+    q5_income_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+        ]
+    )
+    .drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_income_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By household income (2)
+
+# %%
+df = q5_income_tables["uk"]["proportions"].reindex(
+    index=[
+        "under £10,000 per year (net)",
+        "£10,000 to £29,999 per year (net)",
+        "£30,000 to £49,999 per year (net)",
+        "£50,000 to £69,999 per year (net)",
+        "£70,000 to £99,999 per year",
+        "£100,000 to £149,999 per year",
+        "£150,000 and over",
+        "Don't know",
+        "Prefer not to answer",
+    ]
+)
+sns.set(style="whitegrid")
+plt.figure(figsize=(10, 6))
+
+highlight_category = ["Don't know", "Prefer not to answer"]
+bar_colours = [
+    "grey" if category in highlight_category else "darkgreen" for category in df.index
+]
+ax = sns.barplot(
+    x="profile_gross_household", y="Would consider (net)", data=df, palette=bar_colours
+)
+
+for p in ax.patches:
+    ax.annotate(
+        f"{p.get_height():.0f}",  # Add label with one decimal place
+        (
+            p.get_x() + p.get_width() / 2.0,
+            p.get_height(),
+        ),
+        ha="center",
+        va="center",
+        fontsize=9,
+        xytext=(0, 5),
+        textcoords="offset points",
+    )
+
+plt.xlabel("Gross household income", fontsize=10)
+plt.ylabel(
+    "Percentage of income group that would\nconsider installing a heat pump (%)",
+    fontsize=9,
+)
+
+plt.xticks(rotation=90, fontsize=10)
+plt.yticks(fontsize=10)
+plt.ylim(0, 80)
+plt.title("Income group vs. Proportion who would consider installing a heat pump")
+plt.tight_layout()
+plt.show()
+
+# %%
+df = q5_income_tables["uk"]["proportions"].reindex(
+    index=[
+        "under £10,000 per year (net)",
+        "£10,000 to £29,999 per year (net)",
+        "£30,000 to £49,999 per year (net)",
+        "£50,000 to £69,999 per year (net)",
+        "£70,000 to £99,999 per year",
+        "£100,000 to £149,999 per year",
+        "£150,000 and over",
+        "Don't know",
+        "Prefer not to answer",
+    ]
+)
+sns.set(style="whitegrid")
+plt.figure(figsize=(10, 6))
+
+highlight_category = ["Don't know", "Prefer not to answer"]
+bar_colours = [
+    "grey" if category in highlight_category else "darkblue" for category in df.index
+]
+ax = sns.barplot(
+    x="profile_gross_household",
+    y="Wouldn't consider (net)",
+    data=df,
+    palette=bar_colours,
+)
+
+for p in ax.patches:
+    ax.annotate(
+        f"{p.get_height():.0f}",  # Add label with one decimal place
+        (
+            p.get_x() + p.get_width() / 2.0,
+            p.get_height(),
+        ),
+        ha="center",
+        va="center",
+        fontsize=9,
+        xytext=(0, 5),
+        textcoords="offset points",
+    )
+
+plt.xlabel("Gross household income", fontsize=10)
+plt.ylabel(
+    "Percentage of income group that wouldn't\nconsider installing a heat pump (%)",
+    fontsize=9,
+)
+
+plt.xticks(rotation=90, fontsize=10)
+plt.yticks(fontsize=10)
+plt.ylim(0, 80)
+plt.title("Income group vs. Proportion who wouldn't consider installing a heat pump")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## RQ 1. By age (1)
+
+# %% [markdown]
+# The age group with the highest proportion who would consider installing a heat pump (55%) is 25-34. Conversely, the age group with the highest proportion who wouldn't consider installing a heat pump (57%) is 55+.
+
+# %%
+# Create Q5 response breakdown by age table for the UK
+q5_age_tables = {}
+
+# Counts
+q5_age_tables["counts"] = pd.crosstab(
+    index=q5_base_data["profile_julesage"],
+    columns=q5_base_data["PEN_Q5"],
+    values=q5_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+q5_age_tables["proportions"] = pd.crosstab(
+    index=q5_base_data["profile_julesage"],
+    columns=q5_base_data["PEN_Q5"],
+    values=q5_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+q5_age_tables["proportions"]["Total"] = q5_age_tables["proportions"].sum(axis=1)
+q5_age_tables["proportions"] = (q5_age_tables["proportions"] * 100).round(1)
+
+# Add aggregated responses
+for df in q5_age_tables.values():
+    for combined_col, source_cols in q5_response_aggregation_dict.items():
+        df[combined_col] = df[source_cols].sum(axis=1)
+    df.drop(columns="Not asked", inplace=True)
+
+# %%
+age_df = q5_age_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"]
+)
+summary.create_stacked_horizontal_bar_chart(
+    age_df, "Percentage", "Age", 10, (10, 5)
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+q5_age_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5_base_data,
+    proportions_df=q5_age_tables["proportions"],
+    aggregated_responses_column_dict=q5_response_aggregation_dict,
+    aggregated_responses_index_dict={},
+    index_survey_code="profile_julesage",
+).drop(columns="Total")
+
+# %%
+q5_age_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across age groups
+q5_age_counts_summary = q5_age_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index="Total",
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_age_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between age group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between age group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By age (2)
+
+# %% [markdown]
+# There is an association between age and likelihood of considering/not considering a heat pump, with trend being starker when looking at the percentage of respondents who said they wouldn't consider of each age group (28% of 18-24 year olds to 57% of 55+ year olds).
+
+# %%
+sns.set(style="whitegrid")
+plt.figure(figsize=(10, 5))
+
+ax = sns.barplot(
+    x="profile_julesage",
+    y="Would consider (net)",
+    data=q5_age_tables["proportions"],
+    color="darkgreen",
+)
+
+for p in ax.patches:
+    ax.annotate(
+        f"{p.get_height():.0f}",  # Add label with one decimal place
+        (
+            p.get_x() + p.get_width() / 2.0,
+            p.get_height(),
+        ),
+        ha="center",
+        va="center",
+        fontsize=9,
+        xytext=(0, 5),
+        textcoords="offset points",
+    )
+
+plt.xlabel("Age group", fontsize=10)
+plt.ylabel(
+    "Percentage of age group that would\nconsider installing a heat pump (%)",
+    fontsize=9,
+)
+
+plt.xticks(rotation=90, fontsize=10)
+plt.yticks(fontsize=10)
+plt.ylim(0, 80)
+plt.title("Age group vs. Proportion who would consider installing a heat pump")
+plt.tight_layout()
+plt.show()
+
+# %%
+sns.set(style="whitegrid")
+plt.figure(figsize=(10, 5))
+
+ax = sns.barplot(
+    x="profile_julesage",
+    y="Wouldn't consider (net)",
+    data=q5_age_tables["proportions"],
+    color="darkblue",
+)
+
+for p in ax.patches:
+    ax.annotate(
+        f"{p.get_height():.0f}",  # Add label with one decimal place
+        (
+            p.get_x() + p.get_width() / 2.0,
+            p.get_height(),
+        ),
+        ha="center",
+        va="center",
+        fontsize=9,
+        xytext=(0, 5),
+        textcoords="offset points",
+    )
+
+plt.xlabel("Age group", fontsize=10)
+plt.ylabel(
+    "Percentage of age group that wouldn't\nconsider installing a heat pump (%)",
+    fontsize=9,
+)
+
+plt.xticks(rotation=90, fontsize=10)
+plt.yticks(fontsize=10)
+plt.ylim(0, 80)
+plt.title("Age group vs. Proportion who wouldn't consider installing a heat pump")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## RQ 1. Whether home has energy tech, space/infrastructure or boiler replacement opportunity
+
+# %% [markdown]
+# Most people with a type of smart energy technology (i.e. home battery, electric vehicle, electric vehicle charger, solar panels) said they would consider installing a heat pump (55-63%). But only a small percentage of the population have these technologies (2-8%).
+#
+# The largest group by far with a particular thing in their home already is the group with private outdoor space (56% of the UK population), where equal proportions of people said they would (46%) and wouldn't consider (46%) a heat pump.
+
+# %%
+# Compile all options
+q3_options = [
+    option
+    for option in code_question_lookup.keys()
+    if "Q3_" in option and "collapsed" not in option
+]
+
+# Generate counts, proportions and proportions with 95% CI tables
+q3_option_tables = {}
+q3_option_tables_with_ci = {}
+for option in q3_options:
+    # Cast different data type for compatibility with processing
+    q5_base_data.loc[:, option] = q5_base_data[option].astype(str)
+    q5_base_data.loc[:, option] = pd.Categorical(
+        q5_base_data[option], categories=["True", "False"], dtype="category"
+    )
+    q3_option_tables[option], q3_option_tables_with_ci[option] = (
+        summary.generate_q5_outputs(q5_base_data, option, drop_not_asked=False)
+    )
+
+# %%
+# Concatenate all counts, proportions, and proportions_with_ci, dropping unwanted indices
+q3_counts = pd.concat(
+    [
+        q3_option_tables[opt]["counts"].drop(index=["False", "Total"], errors="ignore")
+        for opt in q3_options
+    ],
+    axis=0,
+)
+
+q3_proportions = pd.concat(
+    [
+        q3_option_tables[opt]["proportions"].drop(index=["False"], errors="ignore")
+        for opt in q3_options
+    ],
+    axis=0,
+)
+
+q3_proportions_with_ci = pd.concat(
+    [
+        q3_option_tables_with_ci[opt].drop(index=["False"], errors="ignore")
+        for opt in q3_options
+    ],
+    axis=0,
+)
+
+# Create option names from lookup
+option_names = [
+    (
+        code_question_lookup.get(opt, "").split(":", 1)[1].strip()
+        if ":" in code_question_lookup.get(opt, "")
+        else code_question_lookup.get(opt, "")
+    )
+    for opt in q3_options
+]
+
+# Assign indices
+q3_counts.index = option_names
+q3_proportions.index = option_names
+q3_proportions_with_ci.index = option_names
+
+# %%
+# Display reordered summary table
+q3_proportions_summary = q3_proportions_with_ci.sort_values(
+    by="Would consider (net)", ascending=False
+)[["Would consider (net)", "Wouldn't consider (net)", "Don't know"]]
+q3_proportions_summary = q3_proportions_summary.join(q3_counts["Total"].astype(int))
+q3_proportions_summary = q3_proportions_summary.rename(
+    columns={"Total": "n (% of population)"}
+)
+q3_proportions_summary["n (% of population)"] = q3_proportions_summary[
+    "n (% of population)"
+].apply(lambda x: f"{x} ({(x/6875)*100:.1f}%)")
+
+# %%
+q3_proportions_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across groups
+chi2_stat, p_val, dof, expected = chi2_contingency(
+    q3_counts.drop(columns=["Total", "Would consider (net)", "Wouldn't consider (net)"])
+)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By awareness
+
+# %% [markdown]
+# People who have heard of heat pumps and know what they are have the greatest proportion of those who wouldn't consider installing a heat pump (51%; 31% who said definitely wouldn't consider and 20% who said probably wouldn't consider).
+#
+# The proportions who would consider a heat pump are similar for groups who know what heat pumps are (44%) and who don't know what heat pumps are (46%).
+#
+# Interestingly, knowing/not knowing what heat pumps are doesn't seem to be associated with whether or not someone would consider them as their main heating source - i.e. 44% of people who know what they are vs. 46% of those who don't know what they are.
+#
+# Strangely, the group with the greatest proportion of those who wouldn't consider is the group who does know what they are (51%). This proportion is a notably higher than the groups who have heard of them but don't know what they are (38%) and have never heard of them (31%).
+# - Within the group who know what they are, the most common response was "*Definitely" wouldn't consider" (31%).
+#
+# For those who have never heard of heat pumps, there's a roughly even split between those who would (35%) and wouldn't consider (31%).
+
+# %%
+# Create counts and proportions tables
+q5_q4_tables, q5_q4_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q4"
+)
+
+# %%
+q4_df = q5_q4_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"]
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q4_df,
+    "Percentage",
+    "Before taking this survey, had you ever\nheard of heat pumps as a home heating system?",
+    10,
+    (10, 5),
+).show()
+
+# %%
+q5_q4_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q4 response groups
+q5_q4_counts_summary = q5_q4_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q4_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By whether they had seen a heat pump
+
+# %% [markdown]
+# The group with the highest proportion of people who said they would consider a heat pump was the group who hadn't seen one before (47%), compared to those who had (42%).
+#
+# Respondents who had seen a heat pump before have the highest proportion of people who said they wouldn't consider a heat pump (53%), compared to 39% of those who hadn't.
+#
+# *It seems like the respondents who know the most about them (know how they work and/or have seen one before) are the ones who are more likely to know they definitely wouldn't consider installing a heat pump in their home.*
+
+# %%
+# Create counts and proportions tables
+# 739 not asked (weighted) as they have a heat pump or said they had never heard of heat pumps
+q5_q6_tables, q5_q6_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q6", drop_not_asked=False
+)
+
+# %%
+q6_df = q5_q6_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"],
+    index="Not asked",
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q6_df,
+    "Percentage",
+    "Before taking this survey,\nhave you ever seen what a heat pump looks like?",
+    10,
+    (10, 5),
+).show()
+
+# %%
+q5_q6_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q6 response groups
+q5_q6_counts_summary = q5_q6_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q6_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By whether they had been to a home with a heat pump
+
+# %% [markdown]
+# The proportion who would consider a heat pump of those who have been to a home with a heat pump (51%) is greater than the proportion of those who haven't (41%), but similar to the proportion of those who don't know/can't recall (54%).
+#
+# Similarly, the proportion who said they wouldn't consider a heat pump is lower for the group who have been to a home with a heat pump (45%) than in the group who haven't (50%).
+
+# %%
+# Create counts and proportions tables
+# 739 not asked (weighted) as they have a heat pump or said they had never heard of heat pumps
+q5_q7_tables, q5_q7_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q7", drop_not_asked=False
+)
+
+# %%
+q7_df = q5_q7_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"],
+    index="Not asked",
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q7_df,
+    "Percentage",
+    "Have you ever been to a home that has a heat pump?",
+    10,
+    (10, 5),
+).show()
+
+# %%
+q5_q7_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q7 response groups
+q5_q7_counts_summary = q5_q7_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q7_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By whether family/friends/neighbours own a heat pump
+
+# %% [markdown]
+# Most people who have family/friends/neighbours with a heat pump would consider installing one in their own home (58%). This proportion is notably higher than in those who don't (41%).
+
+# %%
+# Create counts and proportions tables
+# 739 not asked (weighted) as they have a heat pump or said they had never heard of heat pumps
+q5_q8_tables, q5_q8_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q8", drop_not_asked=False
+)
+
+# %%
+q8_df = q5_q8_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"],
+    index="Not asked",
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q8_df,
+    "Percentage",
+    "Does anyone in your family, close friends\nor neighbours own a heat pump?",
+    10,
+    (10, 5),
+).show()
+
+# %%
+q5_q8_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q8 response groups
+q5_q8_counts_summary = q5_q8_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q8_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By whether they have had a conversation with family/friends/neighbours about installing a heat pump
+
+# %% [markdown]
+# Most people who have had a conversation about installing a heat pump would consider one (57%) This proportion is greater than the proportions of those who haven't (41%).
+#
+# Similarly, a lower proportion of those who have had a conversation said they wouldn't consider (40%), compared to those who haven't had a conversation (48%).
+
+# %%
+# Create counts and proportions tables
+# 739 not asked (weighted) as they have a heat pump or said they had never heard of heat pumps
+q5_q9_tables, q5_q9_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q9", drop_not_asked=False
+)
+
+# %%
+q9_df = q5_q9_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"],
+    index="Not asked",
+)
+summary.create_stacked_horizontal_bar_chart(
+    q9_df,
+    "Percentage",
+    "Have you ever had a conversation with your family, close friends\nor neighbours about installing a heat pump in your home?",
+    10,
+    (10, 5),
+).show()
+
+# %%
+q5_q9_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q9 response groups
+q5_q9_counts_summary = q5_q9_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q9_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## Summarising the effects of prior knowledge/experiences
+
+# %% [markdown]
+# **Know what they are**
+# - Know what they are: 44% would consider vs. 51% wouldn't
+# - Have heard of but don't know what they are: 46% vs. 38%
+# - Never heard of: 35% vs. 31%
+#
+# *Knowing what they are does not lead to a greater likelihood of considering.*
+#
+# **Have seen one**
+# - Seen: 42% vs. 53%
+# - Not seen: 47% vs. 39%
+#
+# *Having seen one does not lead to a greater likelihood of considering.*
+#
+# **Been to a home with one**
+# - Been: 51% vs. 45%
+# - Not been: 41% vs. 50%
+#
+# *Having been to a home with a heat pump does lead to a greater likelihood of considering.*
+#
+# **Family/friends/neighbours have one**
+# - Have: 58% vs. 40%
+# - Don't have: 41% vs. 51%
+#
+# *Having family/friends/neighbours with a heat pump does lead to a greater likelihood of considering.*
+#
+# **Have had a conversation about installing one**
+# - Have: 57% vs. 40%
+# - Haven't: 41% vs. 48%
+#
+# *Having a conversation with family/friends/neighbours about installing a heat pump does lead to a greater likelihood of considering.*
+#
+
+# %% [markdown]
+# ## RQ 1. By affordability: Without additional borrowing
+
+# %% [markdown]
+# Unsurprisingly, the groups who said that a heat pump would be very or fairly affordable had greater proportions who said that they are likely to consider a heat pump (64% and 68%, respectively), compared to those who said it would be very or fairly unaffordable (57%, 34%).
+#
+# The split between groups seems to be between the "Fairly unaffordable" and "Very unaffordable" groups - i.e., percentage who would consider of the fairly unaffordable group is closer to the percentages in very/fairly affordable than to the very unaffordable percentage.
+#
+
+# %%
+# Create counts and proportions tables
+q5_q5a_tables, q5_q5a_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q5Anew", drop_not_asked=True
+)
+
+# %%
+q5a_df = q5_q5a_tables["proportions"].drop(
+    columns=["Would consider (net)", "Wouldn't consider (net)", "Total"],
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5a_df,
+    "Percentage",
+    "To what extent, if at all, would installing a heat pump be\naffordable for your household, without taking out additional borrowing?",
+    10,
+    (10, 5),
+).show()
+
+# %%
+q5_q5a_proportions_with_ci = (
+    q5_q5a_proportions_with_ci.join(q5_q5a_tables["counts"]["Total"])
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q5_q5a_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q5A response groups
+q5_q5a_counts_summary = q5_q5a_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q5a_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By willingness to borrow: Mortgage provider
+
+# %% [markdown]
+# Respondents who are more willing to borrow funds via a mortgage provider had higher proportions who said they would consider installing a heat pump. For instance, almost all who were very willing to borrow through a mortgage provider said they would consider (98%).
+
+# %%
+# Create counts and proportions tables
+# Homeowners only
+q5_q5b_tables, q5_q5b_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q5Bnew", drop_not_asked=False
+)
+
+# %%
+q5b_df = q5_q5b_tables["proportions"].drop(
+    columns=[
+        "Would consider (net)",
+        "Wouldn't consider (net)",
+        "Total",
+    ],
+    index="Not asked",
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5b_df,
+    "Percentage",
+    "How willing, if at all, would you be to borrow funds from\na mortgage providerto fund the installation of\nlow carbon heating (such as heat pumps) in your home?",
+    8,
+    (10, 5),
+).show()
+
+# %%
+q5_q5b_proportions_with_ci = (
+    q5_q5b_proportions_with_ci.join(q5_q5b_tables["counts"]["Total"])
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q5_q5b_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q5A response groups
+q5_q5b_counts_summary = q5_q5b_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q5b_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By willingness to borrow: Unsecured borrowing
+
+# %% [markdown]
+# Similarly, respondents who are more willing to borrow funds through unsecured borrowing had higher proportions who said they would consider installing a heat pump.
+
+# %%
+# Create counts and proportions tables
+# Homeowners only
+q5_q5c_tables, q5_q5c_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q5Cnew", drop_not_asked=False
+)
+
+# %%
+q5c_df = q5_q5c_tables["proportions"].drop(
+    columns=[
+        "Would consider (net)",
+        "Wouldn't consider (net)",
+        "Total",
+    ],
+    index="Not asked",
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5c_df,
+    "Percentage",
+    "How willing, if at all, would you be to take out unsecured borrowing\n(e.g. via a personal loan or credit card) in order to fund the installation of\nlow carbon heating (such as heat pumps) in your home?",
+    8,
+    (10, 5),
+).show()
+
+# %%
+q5_q5c_proportions_with_ci = (
+    q5_q5c_proportions_with_ci.join(q5_q5c_tables["counts"]["Total"])
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q5_q5c_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q5A response groups
+q5_q5c_counts_summary = q5_q5c_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q5c_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %%
+## RQ 1. By desire to buy a house with a heat pump
+
+# %%
+# Create counts and proportions tables
+# q5_q5d_tables, q5_q5d_proportions_with_ci = summary.generate_q5_outputs(
+#     q5_base_data, "PEN_Q5Dnew", drop_not_asked=False
+# )
+
+# %%
+# fontsize = 8
+# q5d_df = q5_q5d_tables["proportions"].drop(
+#     columns=[
+#         "Would consider (net)",
+#         "Wouldn't consider (net)",
+#         "Total",
+#     ],
+# )
+# ax = q5d_df.plot(kind="barh", stacked=True, figsize=(10, 5), colormap="Dark2")
+# ax.set_xlabel("Percentage", fontsize=fontsize)
+# ax.set_ylabel(
+#     "How desirable, if at all, would buying a house that has a heat pump be for you?",
+#     fontsize=fontsize,
+# )
+# ax.tick_params(axis="x", labelsize=fontsize)
+# ax.tick_params(axis="y", labelsize=fontsize)
+# ax.legend(loc="center", bbox_to_anchor=(0.5, 1.1), ncol=3, fontsize=fontsize)
+# ax.set_xlim(0, 100)
+# ax.invert_yaxis()
+
+# # Add labels to each segment
+# for c in ax.containers:
+#     for rect in c:
+#         width = rect.get_width()
+#         x_position = rect.get_x() + width / 2
+#         y_position = rect.get_y() + rect.get_height() / 2
+#         ax.text(
+#             x_position,
+#             y_position,
+#             f"{width:.1f}%",
+#             ha="center",
+#             va="center",
+#             fontsize=fontsize,
+#             color="white",
+#         )
+# plt.tight_layout()
+# plt.show()
+
+# %%
+# q5_q5d_proportions_with_ci = q5_q5d_proportions_with_ci.join(
+#     q5_q5d_tables["counts"]["Total"]
+# )
+# q5_q5d_proportions_with_ci = q5_q5d_proportions_with_ci.rename(columns={"Total": "n"})
+# q5_q5d_proportions_with_ci["n"] = q5_q5d_proportions_with_ci["n"].astype(int)
+# q5_q5d_proportions_with_ci
+
+# %%
+# # Chi-squared contingency test across Q5A response groups
+# q5_q5d_counts_summary = q5_q5d_tables["counts"].drop(
+#     columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+#     index=["Total"],
+# )
+# chi2_stat, p_val, dof, expected = chi2_contingency(q5_q5d_counts_summary)
+
+# if p_val < 0.05:
+#     print(
+#         f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+#     )
+# else:
+#     print(
+#         f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+#     )
+
+# %% [markdown]
+# ## RQ 1. By main perceived barrier
+
+# %% [markdown]
+# The question that respondents were asked was: Which ONE of the following factors do you think would prevent you the MOST from installing a heat pump in your home?
+
+# %% [markdown]
+# *This breakdown of results is a little tricky to analyse because we can't be certain it is the reason why they said they wouldn't consider installing a heat pump.*
+#
+# Example statement:
+# - Of the people who said that skepticism over heat pump technology would be the factor that would prevent them the most from installing a heat pump, 72% said they are not likely to consider installing heat pump.
+#
+# Note: Q12 (main barrier) was asked *after* Q5 (would you consider).
+
+# %%
+# Create counts and proportions tables
+# Homeowners only
+q5_q12_tables, q5_q12_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q12", drop_not_asked=False
+)
+
+# %%
+q5_q12_proportions_with_ci = (
+    q5_q12_proportions_with_ci.join(q5_q12_tables["counts"]["Total"])
+    .drop(index="Not asked", errors="ignore")
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+    .sort_values(by="Wouldn't consider (net)", ascending=False)[
+        ["Would consider (net)", "Wouldn't consider (net)", "n"]
+    ]
+)
+
+q5_q12_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q5A response groups
+q5_q12_counts_summary = q5_q12_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q12_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 1. By main perceived benefit
+
+# %% [markdown]
+# The question that respondents were asked: Which ONE of the following benefits about heat pumps is MOST likely to encourage you to install a heat pump in your home in the future?
+
+# %% [markdown]
+# *Similarly to the barrier question, this breakdown of results is a little tricky to analyse because we can't be certain it is the reason why they said they would consider installing a heat pump.*
+#
+# Example statement:
+# - Of the people who said that keeping up with other people would be the factor that would encourage them the most from installing a heat pump, 82% said they are likely to consider installing heat pump.
+#
+# Note: Q14 (main benefit) was asked *after* Q5 (would you consider).
+
+# %%
+# Create counts and proportions tables
+# Homeowners only
+q5_q14_tables, q5_q14_proportions_with_ci = summary.generate_q5_outputs(
+    q5_base_data, "PEN_Q14", drop_not_asked=False
+)
+
+# %%
+q5_q14_proportions_with_ci = (
+    q5_q14_proportions_with_ci.join(q5_q14_tables["counts"]["Total"])
+    .drop(index="Not asked", errors="ignore")
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+    .sort_values(by="Would consider (net)", ascending=False)[
+        ["Would consider (net)", "Wouldn't consider (net)", "n"]
+    ]
+)
+
+q5_q14_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'How likely, if at all, would you be to consider installing a heat pump in your home as your main heating source?'"
+)
+
+# %%
+# Chi-squared contingency test across Q5A response groups
+q5_q14_counts_summary = q5_q14_tables["counts"].drop(
+    columns=["Total", "Would consider (net)", "Wouldn't consider (net)"],
+    index=["Total", "Not asked"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5_q14_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_2_5_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_2_5_summary.py
@@ -1132,3 +1132,167 @@ for experience in hp_experience_lookup.keys():
             print(
                 f"{experience}: A chi-squared test of independence showed no significant relationship between income group and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
             )
+
+# %% [markdown]
+# ## RQ 5. By age
+
+# %% [markdown]
+# - Any experience
+
+# %%
+# Create any experience response breakdown by age table for the UK
+hp_experience_age_tables = {}
+
+# Counts
+hp_experience_age_tables["counts"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["hp_experience_any"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+hp_experience_age_tables["proportions"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["hp_experience_any"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+hp_experience_age_tables["proportions"]["Total"] = hp_experience_age_tables[
+    "proportions"
+].sum(axis=1)
+hp_experience_age_tables["proportions"] = (
+    hp_experience_age_tables["proportions"] * 100
+).round(1)
+
+# %%
+hp_experience_age_tables["proportions"]
+
+# %% [markdown]
+# - PEN_Q6: Before taking this survey, have you ever seen what a heat pump looks like?
+
+# %%
+# Create Q6 response breakdown by age table for the UK
+q6_age_tables = {}
+
+# Counts
+q6_age_tables["counts"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q6"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+q6_age_tables["proportions"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q6"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+q6_age_tables["proportions"]["Total"] = q6_age_tables["proportions"].sum(axis=1)
+q6_age_tables["proportions"] = (q6_age_tables["proportions"] * 100).round(1)
+
+# %%
+q6_age_tables["proportions"]
+
+# %% [markdown]
+# - PEN_Q7: Have you ever been to a home that has a heat pump?
+
+# %%
+# Create Q7 response breakdown by age table for the UK
+q7_age_tables = {}
+
+# Counts
+q7_age_tables["counts"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q7"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+q7_age_tables["proportions"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q7"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+q7_age_tables["proportions"]["Total"] = q7_age_tables["proportions"].sum(axis=1)
+q7_age_tables["proportions"] = (q7_age_tables["proportions"] * 100).round(1)
+
+# %%
+q7_age_tables["proportions"]
+
+# %% [markdown]
+# - PEN_Q8: Does anyone in your family, close friends or neighbours own a heat pump?
+
+# %%
+# Create Q8 response breakdown by age table for the UK
+q8_age_tables = {}
+
+# Counts
+q8_age_tables["counts"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q8"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+q8_age_tables["proportions"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q8"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+q8_age_tables["proportions"]["Total"] = q8_age_tables["proportions"].sum(axis=1)
+q8_age_tables["proportions"] = (q8_age_tables["proportions"] * 100).round(1)
+
+# %%
+q8_age_tables["proportions"]
+
+# %% [markdown]
+# - PEN_Q9: Have you ever had a conversation with your family, close friends or neighbours about installing a heat pump in your home?
+
+# %%
+# Create Q9 response breakdown by age table for the UK
+q9_age_tables = {}
+
+# Counts
+q9_age_tables["counts"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q9"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+q9_age_tables["proportions"] = pd.crosstab(
+    index=q6_base_data["profile_julesage"],
+    columns=q6_base_data["PEN_Q9"],
+    values=q6_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+q9_age_tables["proportions"]["Total"] = q9_age_tables["proportions"].sum(axis=1)
+q9_age_tables["proportions"] = (q9_age_tables["proportions"] * 100).round(1)
+
+# %%
+q9_age_tables["proportions"]
+
+# %%

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_2_5_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_2_5_summary.py
@@ -1,0 +1,1134 @@
+# -*- coding: utf-8 -*-
+# ---
+# title: "RQs 2 & 5. Prior awareness and exposure"
+# format:
+#   revealjs:
+#     scrollable: true
+#     smaller: true
+#     embed-resources: true
+#     css: styles.css
+#     slide-number: true
+#     footer: "Identifying the next three million heat pump owners: YouGov Survey (RQs 2 & 5. Prior awareness and exposure)"
+# execute:
+#   enabled: true
+#   echo: false
+#   output: true
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_next_three_million_heat_pump_owners
+#     language: python
+#     name: python3
+# ---
+
+# %%
+## Instructions for rendering
+# 1. Save as a separate .ipynb file
+# 2. Run: quarto render asf_next_three_million_heat_pump_owners/notebooks/[FILE_NAME].ipynb --to revealjs
+
+# %%
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm, chi2_contingency
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.getters import load_data
+
+# %%
+# Load cleaned data
+data, wales_data = load_data.get_analysis_ready_data()
+
+# Get code to full question look-up dictionary
+code_question_lookup = config.get("code_question_lookup")
+
+# %%
+# Load cleaned data
+cleaned_data_path = f"""/mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2. Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov survey data/Analysis ready data/20250409_yougov_survey_clean_data.parquet"""
+data = pd.read_parquet(cleaned_data_path, engine="pyarrow")
+code_question_lookup = config.get("code_question_lookup")
+
+cleaned_wales_data_path = f"""/mnt/g/Shared drives/A Sustainable Future/1. Reducing household emissions/2. Projects Research Work/51.Identifying the next 3 million heat pump owners/YouGov survey data/Analysis ready data/20250514_yougov_survey_clean_data_wales_boost.parquet"""
+wales_data = pd.read_parquet(cleaned_wales_data_path)
+
+# %% [markdown]
+# # RQ 2. Before taking this survey, had UK householders ever heard of heat pumps as a home heating system?
+
+# %% [markdown]
+# ## Question that respondents were asked
+#
+# Before taking this survey, had you ever heard of heat pumps as a home heating system?
+# (Please select the option that best applies)
+
+# %% [markdown]
+# ## Number of respondents
+# - Respondents who said they had a heat pump were not asked (n = 135).
+# - From recoding free text responses, however, we identified three responses that indicated that the respondent has a heat pump. As these respondents should not have been asked, we have excluded them from the question base.
+# - Base (unweighted): 6,890
+# - Base (unweighted), after recoding: 6,887
+# - Base (weighted), after recoding: 6,875
+
+# %%
+q4_base_data = data[~(data["PEN_Q2_3_recoded"] == True)]
+
+# %%
+# n = 16 excluded from Wales dataset who have a heat pump
+q4_base_data_wales = wales_data[~(wales_data["PEN_Q2_3_recoded"] == True)]
+
+# %% [markdown]
+# ## RQ 2. Overall
+
+# %% [markdown]
+# Most people had heard of heat pumps (89%), comprising of 55% who know what they are and 34% who don't.
+
+# %%
+# Summary dataframe
+q4_uk = summary.create_single_question_summary_frame(q4_base_data, "PEN_Q4")
+
+# Rename columns
+q4_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q4_uk = q4_uk.drop(index="Not asked").dropna().round(1)
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q4_base_data, "PEN_Q4", "weight") * 100
+q4_uk = q4_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Display only select columns
+q4_uk = q4_uk.round(1)
+q4_uk[
+    ["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]
+].style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).format(
+    {
+        "Weighted count": "{:.0f}",
+        "Weighted percentage": "{:.1f}",
+        "Lower CI": "{:.1f}",
+        "Upper CI": "{:.1f}",
+        "SE": "{:.1f}",
+    }
+).set_caption(
+    "Before taking this survey, had you ever heard of heat pumps as a home heating system?"
+)
+
+# %% [markdown]
+# ## RQ 2. By nation
+
+# %% [markdown]
+# The proportions of responses are similar across E/S/W.
+
+# %%
+# Individual nation datasets
+q4_base_data_england = q4_base_data[q4_base_data["gornewUK_6"] == True]
+# q4_base_data_wales = q4_base_data[q4_base_data["gornewUK_7"] == True]
+q4_base_data_scotland = q4_base_data[q4_base_data["gornewUK_8"] == True]
+q4_base_data_ni = q4_base_data[q4_base_data["gornewUK_9"] == True]
+
+# Dataset lookup dictionary
+q4_base_data_lookup = {
+    "uk": q4_base_data,
+    "england": q4_base_data_england,
+    "wales": q4_base_data_wales,
+    "scotland": q4_base_data_scotland,
+    "ni": q4_base_data_ni,
+}
+
+# Create comparison table for all nations and UK
+q4_nations_df, q4_nations_pct_df = summary.create_nations_summary_tables(
+    q4_base_data, q4_base_data_wales, "PEN_Q4", True
+)
+q4_nations_pct_df = q4_nations_pct_df.drop(["Northern Ireland", "UK"])
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q4_nations_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q4_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q4", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q4_nations_pct_df_ci = q4_nations_pct_df.copy(deep=True)
+
+q4_nations_pct_df_ci = q4_nations_pct_df_ci.astype(str)
+
+for index in q4_nations_pct_df_ci.index:
+    for response in q4_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q4_nations_pct_df_ci.loc[index, response] = (
+            f"""{q4_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+# Add sample size
+q4_nations_pct_df_ci = (
+    q4_nations_pct_df_ci.join(q4_nations_df["Nation total"])
+    .assign(Nation_total=lambda df: df["Nation total"].round(0).astype(int))
+    .rename(columns={"Nation total": "n"})
+)
+
+# Format display
+q4_nations_pct_df_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'Before taking this survey, had you ever heard of heat pumps as a home heating system?'"
+)
+
+# %% [markdown]
+# ## RQ 2. By tenure
+
+# %% [markdown]
+# Most people of all tenure types have heard of heat pumps, with homeowners having the highest proportion (95%).
+#
+# Homeowners also have the greatest proportion of respondents who know what heat pumps are (66%), compared to renters (39%) and others (38%).
+
+# %%
+# Create Q4 response breakdown by tenure table for each nation
+
+# Define response aggregation structure
+q4_response_aggregation_dict = {
+    "Have heard (net)": [
+        "I have heard of heat pumps, and I know what they are",
+        "I have heard of heat pumps, but I don't know what they are",
+    ],
+}
+
+q4_tenure_tables = {}
+for group, base_data in q4_base_data_lookup.items():
+    tables = {}
+    counts_by_tenure, proportions_by_tenure = summary.generate_tenure_breakdown(
+        base_data, "PEN_Q4", q4_response_aggregation_dict, proportions_axis=1
+    )
+    tables["counts"] = counts_by_tenure
+    tables["proportions"] = proportions_by_tenure
+
+    q4_tenure_tables[group] = tables
+
+# %%
+# Plot broad tenure categories comparison
+q4_tenure_pct_df = (
+    q4_tenure_tables["uk"]["proportions"]
+    .reindex(index=["Own (net)", "Rent (net)", "Neither (net)", "Other"])
+    .drop(columns=["Total", "Have heard (net)"])
+)
+summary.create_stacked_horizontal_bar_chart(
+    q4_tenure_pct_df, "Percentage", "Tenure", 10, (10, 5)
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+# Aggregated responses to profile_house_tenure
+aggregated_responses_tenure = {
+    "Own (net)": [
+        "Own - outright",
+        "Own - with a mortgage",
+        "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+    ],
+    "Rent (net)": [
+        "Rent - from a private landlord",
+        "Rent - from my local authority",
+        "Rent - from a housing association",
+    ],
+    "Neither (net)": [
+        "Neither - I live with my parents, family or friends but pay some rent to them",
+        "Neither - I live rent-free with my parents, family or friends",
+    ],
+}
+
+q4_tenure_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q4_base_data,
+    proportions_df=q4_tenure_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q4_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_tenure,
+    index_survey_code="profile_house_tenure",
+).drop(columns="Total")
+
+# %%
+# Display broad tenure categories for UK, proportions with 95% CI
+q4_tenure_proportions_with_ci_summary = (
+    q4_tenure_proportions_with_ci.join(q4_tenure_tables["uk"]["counts"]["Total"])
+    .assign(Total=lambda df: df["Total"].round(0).astype(int))
+    .rename(columns={"Total": "n"})
+)
+
+q4_tenure_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'Before taking this survey, had you ever heard of heat pumps as a home heating system?'"
+)
+
+# %%
+# Chi-squared contingency test across tenure
+q4_tenure_counts_summary = q4_tenure_tables["uk"]["counts"].drop(
+    index=["Own (net)", "Rent (net)", "Neither (net)", "Total"],
+    columns=["Total", "Have heard (net)"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q4_tenure_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 2. By household income
+
+# %% [markdown]
+# Most people in all income brackets have heard of heat pumps, but the proportion is generally greater in higher income brackets. The income bracket with the largest share of people who have heard of heat pumps is £100-150k. The income bracket with the largest proportion who have never heard of heat pumps is <£10k.
+
+# %%
+# Create Q5 response breakdown by tenure table for each nation
+q4_income_tables = {}
+for group, base_data in q4_base_data_lookup.items():
+    tables = {}
+    counts_by_income, proportions_by_income = summary.generate_income_breakdown(
+        base_data,
+        "PEN_Q4",
+        q4_response_aggregation_dict,
+        proportions_axis=1,
+        aggregate_income=True,
+    )
+    tables["counts"] = counts_by_income
+    tables["proportions"] = proportions_by_income
+
+    q4_income_tables[group] = tables
+
+# %%
+# Plot income bracket comparison table
+q4_income_pct_df = (
+    q4_income_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .drop(columns=["Total", "Have heard (net)"])
+)
+summary.create_stacked_horizontal_bar_chart(
+    q4_income_pct_df, "Percentage", "Income bracket", 10, (10, 5)
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+
+# Aggregated responses to profile_gross_household
+aggregated_responses_income = {
+    "under £10,000 per year (net)": [
+        "under £5,000 per year",
+        "£5,000 to £9,999 per year",
+    ],
+    "£10,000 to £29,999 per year (net)": [
+        "£10,000 to £14,999 per year",
+        "£15,000 to £19,999 per year",
+        "£20,000 to £24,999 per year",
+        "£25,000 to £29,999 per year",
+    ],
+    "£30,000 to £49,999 per year (net)": [
+        "£30,000 to £34,999 per year",
+        "£35,000 to £39,999 per year",
+        "£40,000 to £44,999 per year",
+        "£45,000 to £49,999 per year",
+    ],
+    "£50,000 to £69,999 per year (net)": [
+        "£50,000 to £59,999 per year",
+        "£60,000 to £69,999 per year",
+    ],
+}
+
+q4_income_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q4_base_data,
+    proportions_df=q4_income_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q4_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_income,
+    index_survey_code="profile_gross_household",
+).drop(columns="Total")
+
+# %%
+# Show only aggregated income brackets
+q4_income_proportions_with_ci_summary = (
+    q4_income_proportions_with_ci.reindex(
+        [
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .join(q4_income_tables["uk"]["counts"]["Total"].round(0))
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q4_income_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'Before taking this survey, had you ever heard of heat pumps as a home heating system?'"
+)
+
+# %%
+# Chi-squared contingency test across income brackets (net)
+q4_income_counts_summary = (
+    q4_income_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+        ]
+    )
+    .drop(columns=["Total", "Have heard (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q4_income_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 2. By age
+
+# %% [markdown]
+# The proportion of people who have heard of heat pumps increases with increasing age group. For instance, 75% of 18-24 year olds vs. 96% of 55+ year olds.
+
+# %%
+# Create Q5 response breakdown by age table for the UK
+q4_age_tables = {}
+
+# Counts
+q4_age_tables["counts"] = pd.crosstab(
+    index=q4_base_data["profile_julesage"],
+    columns=q4_base_data["PEN_Q4"],
+    values=q4_base_data["weight"],
+    aggfunc="sum",
+    margins=True,
+    margins_name="Total",
+)
+
+# Proportions
+q4_age_tables["proportions"] = pd.crosstab(
+    index=q4_base_data["profile_julesage"],
+    columns=q4_base_data["PEN_Q4"],
+    values=q4_base_data["weight"],
+    aggfunc="sum",
+    normalize="index",
+)
+q4_age_tables["proportions"]["Total"] = q4_age_tables["proportions"].sum(axis=1)
+q4_age_tables["proportions"] = (q4_age_tables["proportions"] * 100).round(1)
+
+# Add aggregated responses
+for df in q4_age_tables.values():
+    df["Have heard (net)"] = (
+        df["I have heard of heat pumps, and I know what they are"]
+        + df["I have heard of heat pumps, but I don't know what they are"]
+    )
+    df.drop(columns="Not asked", inplace=True)
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q4_age_tables["proportions"].drop(columns=["Have heard (net)", "Total"]),
+    "Percentage",
+    "Age group",
+    10,
+    (10, 5),
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+q4_age_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q4_base_data,
+    proportions_df=q4_age_tables["proportions"],
+    aggregated_responses_column_dict=q4_response_aggregation_dict,
+    aggregated_responses_index_dict={},
+    index_survey_code="profile_julesage",
+).drop(columns="Total")
+
+q4_age_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) responses to 'Before taking this survey, had you ever heard of heat pumps as a home heating system?'"
+)
+
+# %%
+# Chi-squared contingency test across age groups
+q4_age_counts_summary = q4_age_tables["counts"].drop(
+    columns=["Total", "Have heard (net)"],
+    index="Total",
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q4_age_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between age group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between age group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %%
+## RQ 2. Whether home has energy tech, space/infrastructure or boiler replacement opportunity
+
+# %%
+# # Create combined counts and proportion tables
+# q3_options = [
+#     option
+#     for option in code_question_lookup.keys()
+#     if "Q3_" in option and "collapsed" not in option
+# ]
+
+# q3_q4_option_tables = {}
+# for option in q3_options:
+#     counts = pd.crosstab(
+#         index=q4_base_data[option],
+#         columns=q4_base_data["PEN_Q4"],
+#         values=q4_base_data["weight"],
+#         aggfunc="sum",
+#         margins=True,
+#         margins_name="Total",
+#     ).drop(columns="Not asked")
+#     proportions = (
+#         pd.crosstab(
+#             index=q4_base_data[option],
+#             columns=q4_base_data["PEN_Q4"],
+#             values=q4_base_data["weight"],
+#             aggfunc="sum",
+#             margins=True,
+#             normalize="index",
+#         ).drop(columns="Not asked")
+#         * 100
+#     ).round(1)
+#     q3_q4_option_tables[option] = {"counts": counts, "proportions": proportions}
+
+# q3_q4_counts = pd.DataFrame()
+# q3_q4_proportions = pd.DataFrame()
+# for option in q3_options:
+#     q3_q4_counts = pd.concat(
+#         [q3_q4_counts, q3_q4_option_tables[option]["counts"]], axis=0
+#     ).drop(index=[False, "Total"])
+#     q3_q4_proportions = pd.concat(
+#         [q3_q4_proportions, q3_q4_option_tables[option]["proportions"]], axis=0
+#     ).drop(index=[False, "All"])
+
+# option_names = []
+# for option in q3_options:
+#     option_names.append(f"{code_question_lookup.get(option).split(':')[1]}")
+# q3_q4_counts.index = option_names
+# q3_q4_proportions.index = option_names
+
+# for df in [q3_q4_counts, q3_q4_proportions]:
+#     df.loc[:, "Have heard (net)"] = (
+#         df.loc[:, "I have heard of heat pumps, and I know what they are"]
+#         + df.loc[:, "I have heard of heat pumps, but I don't know what they are"]
+#     )
+
+# %%
+# 95% confidence intervals for proportions
+# To be completed
+
+# %%
+# # Display reordered summary table
+# q3_q4_proportions_summary = q3_q4_proportions.sort_values(
+#     by="Have heard (net)", ascending=False
+# )
+# q3_q4_proportions_summary = q3_q4_proportions_summary.join(
+#     q3_q4_counts["Total"].astype(int)
+# )
+# q3_q4_proportions_summary = q3_q4_proportions_summary.rename(
+#     columns={"Total": "n (% of population)"}
+# )
+# q3_q4_proportions_summary["n (% of population)"] = q3_q4_proportions_summary[
+#     "n (% of population)"
+# ].apply(lambda x: f"{x} ({(x/6875)*100:.1f}%)")
+# q3_q4_proportions_summary
+
+# %% [markdown]
+# # RQ 5. What experiences have people had with heat pumps?
+
+# %% [markdown]
+# ## Question that respondents were asked
+
+# %% [markdown]
+# - PEN_Q6: Before taking this survey, have you ever seen what a heat pump looks like?
+# - PEN_Q7: Have you ever been to a home that has a heat pump?
+# - PEN_Q8: Does anyone in your family, close friends or neighbours own a heat pump?
+# - PEN_Q9: Have you ever had a conversation with your family, close friends or neighbours about installing a heat pump in your home?
+
+# %% [markdown]
+# ## Number of respondents
+# - Respondents who said they had a heat pump (n = 135) or said they had never heard of heat pumps (n = 645) were not asked.
+# - From recoding free text responses, however, we identified three responses that indicated that the respondent has a heat pump. As these respondents should not have been asked, we have excluded them from the question base.
+# - Base (unweighted): 6,245
+# - Base (unweighted), after recoding: 6,242
+# - Base (weighted), after recoding: 6,136
+
+# %%
+q6_base_data = data[
+    ~(data["PEN_Q2_3_recoded"] == True)
+    & ~(data["PEN_Q4"] == "I have never heard of heat pumps")
+]
+
+# %%
+q6_base_data_wales = wales_data[
+    ~(wales_data["PEN_Q2_3_recoded"] == True)
+    & ~(wales_data["PEN_Q4"] == "I have never heard of heat pumps")
+]
+
+# %%
+hp_experience_lookup = {
+    "hp_experience_6": "Seen a heat pump",
+    "hp_experience_7": "Been to a home with a heat pump",
+    "hp_experience_8": "Family/close friends/neighbours have a heat pump",
+    "hp_experience_9": "Have had a conversation about installing a heat pump",
+    "hp_experience_any": "At least one experience",
+}
+
+# %%
+# Convert to multiple column "select all that apply" format
+q6_base_data = q6_base_data.copy()
+
+for label in ["6", "7", "8", "9"]:
+    if label == "8":
+        q6_base_data[f"hp_experience_{label}"] = (
+            q6_base_data[f"PEN_Q{label}"] == "Yes, they do"
+        )
+    else:
+        q6_base_data[f"hp_experience_{label}"] = (
+            q6_base_data[f"PEN_Q{label}"] == "Yes, I have"
+        )
+    q6_base_data[f"hp_experience_{label}"] = pd.Categorical(
+        q6_base_data[f"hp_experience_{label}"], categories=[True, False]
+    )
+
+# Create a column for any experience
+q6_base_data["hp_experience_any"] = q6_base_data[
+    [f"hp_experience_{label}" for label in ["6", "7", "8", "9"]]
+].any(axis=1)
+
+# %%
+# Repeat for Wales data
+q6_base_data_wales = q6_base_data_wales.copy()
+
+for label in ["6", "7", "8", "9"]:
+    if label == "8":
+        q6_base_data_wales[f"hp_experience_{label}"] = (
+            q6_base_data_wales[f"PEN_Q{label}"] == "Yes, they do"
+        )
+    else:
+        q6_base_data_wales[f"hp_experience_{label}"] = (
+            q6_base_data_wales[f"PEN_Q{label}"] == "Yes, I have"
+        )
+    q6_base_data_wales[f"hp_experience_{label}"] = pd.Categorical(
+        q6_base_data_wales[f"hp_experience_{label}"], categories=[True, False]
+    )
+
+# Create a column for any experience
+q6_base_data_wales["hp_experience_any"] = q6_base_data_wales[
+    [f"hp_experience_{label}" for label in ["6", "7", "8", "9"]]
+].any(axis=1)
+
+# %% [markdown]
+# ## RQ 5. UK and by nation
+
+# %% [markdown]
+# **At least one experience**
+#
+# Overall in the UK, most people have had at least one prior experience with heat pumps (57%). This proportion is similar across E/S/W, with it being slightly higher in Wales (61%).
+#
+# **Seen a heat pump**
+#
+# Around half of people in each nation, and overall in the UK, have seen what a heat pump looks like. This proportion again is slightly higher in wales (56%).
+#
+# **Been to a home with a heat pump**
+#
+# Around 1 in 7 people in England and Wales, and overall in the UK, have been to a home with a heat pump. This is higher in Scotland where it is 1 in 5.
+#
+# **Family/close friends/neighbours have a heat pump**
+#
+# Around 1 in 10 people said they know that they have family, close friends or neighbours with a heat pump. This proportion is slightly higher in Scotland (14%).
+#
+# **Have had a conversation with family/close friends/neighbours about installing a heat pump**
+#
+# About 1 in 5 in England and UK overall have had a conversation about installing a heat pump. This proportion is higher in Scotland and Wales where it is about 1 in 4.
+#
+#
+
+# %%
+# Create nation summary tables
+q6_base_data_england = q6_base_data[q6_base_data["gornewUK_6"] == True]
+# q6_base_data_wales = q6_base_data[q6_base_data["gornewUK_7"] == True]
+q6_base_data_scotland = q6_base_data[q6_base_data["gornewUK_8"] == True]
+q6_base_data_ni = q6_base_data[q6_base_data["gornewUK_9"] == True]
+
+q6_base_data_lookup = {
+    "uk": q6_base_data,
+    "england": q6_base_data_england,
+    "wales": q6_base_data_wales,
+    "scotland": q6_base_data_scotland,
+    "ni": q6_base_data_ni,
+}
+
+hp_experience_tables = {}
+for experience in hp_experience_lookup.keys():
+    counts, proportions = summary.create_nations_summary_tables(
+        q6_base_data, q6_base_data_wales, experience, False
+    )
+    counts = counts.drop("Northern Ireland")
+    proportions = proportions.drop("Northern Ireland")
+    hp_experience_tables[experience] = {"counts": counts, "proportions": proportions}
+
+# %%
+# Summarise all experiences
+hp_experience_counts = pd.DataFrame()
+hp_experience_proportions = pd.DataFrame()
+
+for experience in hp_experience_lookup.keys():
+    hp_experience_counts = pd.concat(
+        [hp_experience_counts, hp_experience_tables[experience]["counts"][True]], axis=1
+    )
+    hp_experience_proportions = pd.concat(
+        [
+            hp_experience_proportions,
+            hp_experience_tables[experience]["proportions"][True],
+        ],
+        axis=1,
+    )
+
+for df in [hp_experience_counts, hp_experience_proportions]:
+    df.columns = [
+        "Seen a heat pump",
+        "Been to a home with a heat pump",
+        "Family/close friends/neighbours have a heat pump",
+        "Have had a conversation about installing a heat pump",
+        "At least one experience",
+    ]
+
+# %%
+experience_df = (
+    hp_experience_proportions.drop(index="UK")
+    .reset_index()
+    .rename(columns={"index": "Nation"})
+)
+experience_df_long = experience_df.melt(
+    id_vars="Nation", var_name="Experience", value_name="Percentage"
+)
+
+plt.figure(figsize=(10, 5))
+ax = sns.barplot(data=experience_df_long, y="Experience", x="Percentage", hue="Nation")
+ax.xaxis.grid(True, linestyle="-", alpha=0.3)
+plt.xlabel("Percentage (%)")
+plt.ylabel("Experience")
+plt.legend(title="Nation")
+plt.tight_layout()
+plt.show()
+
+# %%
+# Compile 95% ci tables for each experience and each nation
+hp_experience_props_ci = {}
+for nation, nation_data in q6_base_data_lookup.items():
+    nation_tables = {}
+    for i in [6, 7, 8, 9, "any"]:
+        nation_tables[f"hp_experience_{i}"] = (
+            summary.weighted_props_ci(nation_data, f"hp_experience_{i}", "weight") * 100
+        ).round(1)
+    hp_experience_props_ci[nation] = nation_tables
+
+# Modify original nation comparison tables with lower and upper CI values
+hp_experience_proportions_with_ci = hp_experience_proportions.copy(deep=True)
+hp_experience_proportions_with_ci = hp_experience_proportions_with_ci.astype(str)
+
+for experience in hp_experience_lookup.keys():
+    for index in hp_experience_proportions_with_ci.index:
+        lower = hp_experience_props_ci[index.lower()][experience].loc[True, "Lower CI"]
+        upper = hp_experience_props_ci[index.lower()][experience].loc[True, "Upper CI"]
+
+        hp_experience_proportions_with_ci.loc[
+            index, hp_experience_lookup[experience]
+        ] = f"""{hp_experience_proportions_with_ci.loc[index, hp_experience_lookup[experience]]} ({lower}-{upper})"""
+
+# %%
+hp_experience_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) who have had prior experience with heat pumps"
+)
+
+# %%
+# Chi-squared contingency test across nations
+# Each experience question
+
+for experience in hp_experience_lookup.keys():
+    if experience != "hp_experience_any":
+        chi2_stat, p_val, dof, expected = chi2_contingency(
+            hp_experience_tables[experience]["counts"].drop(
+                index="UK", columns="Nation total"
+            )
+        )
+
+        if p_val < 0.05:
+            print(
+                f"{experience}: A chi-squared test of independence found a significant association between nations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+        else:
+            print(
+                f"{experience}: A chi-squared test of independence showed no significant relationship between nations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+
+# %% [markdown]
+# ## RQ 5. By tenure
+
+# %% [markdown]
+# Homeowners have the highest proportion who have had at least one prior experience with heat pumps (65%), compared to 42% of renters and 44% of others.
+#
+# The tenure subgroup who have the highest proportion who have had at least one prior experience is outright homeowners (70%). Conversely, people who rent from local authority have the lowest proportion (36%).
+
+# %%
+# Create experience and tenure breakdown tables (counts and proportions) for each nation
+experience_tenure_tables = {}
+for experience in hp_experience_lookup.keys():
+    experience_tenure_tables[experience] = {}
+    for group, base_data in q6_base_data_lookup.items():
+        tables = {}
+        counts_by_response, proportions_by_response = summary.generate_tenure_breakdown(
+            base_data, experience, proportions_axis=1
+        )
+        tables["counts"] = counts_by_response
+        tables["proportions"] = proportions_by_response
+
+        experience_tenure_tables[experience][group] = tables
+
+# %%
+# Combine all experiences in one table
+hp_experience_tenure_counts = pd.concat(
+    [
+        experience_tenure_tables[experience]["uk"]["counts"][True]
+        for experience in hp_experience_lookup.keys()
+    ],
+    axis=1,
+)
+
+hp_experience_tenure_proportions = pd.concat(
+    [
+        experience_tenure_tables[experience]["uk"]["proportions"][True]
+        for experience in hp_experience_lookup.keys()
+    ],
+    axis=1,
+)
+
+for df in [hp_experience_tenure_counts, hp_experience_tenure_proportions]:
+    df.columns = [
+        "Seen a heat pump",
+        "Been to a home with a heat pump",
+        "Family/close friends/neighbours have a heat pump",
+        "Have had a conversation about installing a heat pump",
+        "At least one experience",
+    ]
+
+# %%
+experience_tenure_df = (
+    hp_experience_tenure_proportions.reindex(
+        index=["Own (net)", "Rent (net)", "Neither (net)", "Other"]
+    )
+    .reset_index()
+    .rename(columns={"profile_house_tenure": "Tenure"})
+)
+
+experience_tenure_df_long = experience_tenure_df.melt(
+    id_vars="Tenure", var_name="Experience", value_name="Percentage"
+)
+
+plt.figure(figsize=(10, 6))
+ax = sns.barplot(
+    data=experience_tenure_df_long, y="Experience", x="Percentage", hue="Tenure"
+)
+ax.xaxis.grid(True, linestyle="-", alpha=0.3)
+plt.xlabel("Percentage of tenure subpopulation (%)")
+plt.ylabel("Experience")
+plt.legend(title="Tenure")
+plt.tight_layout()
+plt.show()
+
+# %%
+# Compile 95% ci tables for each experience
+experience_tenure_tables_with_ci = {}
+for experience in hp_experience_lookup.keys():
+    experience_tenure_tables[experience]["uk"]["proportions"].columns = (
+        experience_tenure_tables[experience]["uk"]["proportions"].columns.astype(str)
+    )
+    df = summary.modify_proportion_crosstab_with_ci(
+        q6_base_data,
+        experience_tenure_tables[experience]["uk"]["proportions"],
+        aggregated_responses_column_dict={},
+        aggregated_responses_index_dict=aggregated_responses_tenure,
+        index_survey_code="profile_house_tenure",
+    )
+    experience_tenure_tables_with_ci[experience] = df
+
+# Combine all experiences in one table
+hp_experience_tenure_proportions_with_ci = pd.concat(
+    [
+        experience_tenure_tables_with_ci[experience]["True"]
+        for experience in hp_experience_lookup.keys()
+    ],
+    axis=1,
+)
+hp_experience_tenure_proportions_with_ci.columns = [
+    "Seen a heat pump",
+    "Been to a home with a heat pump",
+    "Family/close friends/neighbours have a heat pump",
+    "Have had a conversation about installing a heat pump",
+    "At least one experience",
+]
+
+hp_experience_tenure_proportions_with_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) who have had prior experience with heat pumps"
+)
+
+# %%
+# Chi-squared contingency test across tenure groups
+# Each experience question
+
+for experience in hp_experience_lookup.keys():
+    if experience != "hp_experience_any":
+        chi2_stat, p_val, dof, expected = chi2_contingency(
+            experience_tenure_tables[experience]["uk"]["counts"].drop(
+                index=["Own (net)", "Rent (net)", "Neither (net)", "Other"],
+                columns="Total",
+            )
+        )
+
+        if p_val < 0.05:
+            print(
+                f"{experience}: A chi-squared test of independence found a significant association between tenure group and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+        else:
+            print(
+                f"{experience}: A chi-squared test of independence showed no significant relationship between tenure group and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+
+# %% [markdown]
+# ## RQ 5. By income
+
+# %% [markdown]
+# Higher income brackets have higher proportion of those with prior experience with heat pumps, across all experience types. For example, 73% of people with household income over £150k have had at least one prior experience compared to 40% of those who earn under <£10k.
+
+# %%
+# Create experience and tenure breakdown tables (counts and proportions) for each nation
+experience_income_tables = {}
+for experience in hp_experience_lookup.keys():
+    experience_income_tables[experience] = {}
+    for group, base_data in q6_base_data_lookup.items():
+        tables = {}
+        counts_by_response, proportions_by_response = summary.generate_income_breakdown(
+            base_data, experience, proportions_axis=1
+        )
+        tables["counts"] = counts_by_response
+        tables["proportions"] = proportions_by_response
+
+        experience_income_tables[experience][group] = tables
+
+# %%
+# Combine all experiences in one table
+hp_experience_income_counts = pd.concat(
+    [
+        experience_income_tables[experience]["uk"]["counts"][True]
+        for experience in hp_experience_lookup.keys()
+    ],
+    axis=1,
+)
+
+hp_experience_income_proportions = pd.concat(
+    [
+        experience_income_tables[experience]["uk"]["proportions"][True]
+        for experience in hp_experience_lookup.keys()
+    ],
+    axis=1,
+)
+
+for df in [hp_experience_income_counts, hp_experience_income_proportions]:
+    df.columns = [
+        "Seen a heat pump",
+        "Been to a home with a heat pump",
+        "Family/close friends/neighbours have a heat pump",
+        "Have had a conversation about installing a heat pump",
+        "At least one experience",
+    ]
+
+# %%
+experience_income_df = (
+    hp_experience_income_proportions.reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            # "Don't know",
+            # "Prefer not to answer",
+        ]
+    )
+    .reset_index()
+    .rename(columns={"profile_gross_household": "Income"})
+)
+experience_income_df_long = experience_income_df.melt(
+    id_vars="Income", var_name="Experience", value_name="Percentage"
+)
+
+plt.figure(figsize=(9, 9))
+ax = sns.barplot(
+    data=experience_income_df_long, y="Experience", x="Percentage", hue="Income"
+)
+ax.xaxis.grid(True, linestyle="-", alpha=0.3)
+plt.xlabel("Percentage of income subpopulation (%)")
+plt.ylabel("Experience")
+plt.legend(title="Income")
+plt.tight_layout()
+plt.show()
+
+# %%
+# Compile 95% ci tables for each experience
+
+experience_income_tables_with_ci = {}
+for experience in hp_experience_lookup.keys():
+    experience_income_tables[experience]["uk"]["proportions"].columns = (
+        experience_income_tables[experience]["uk"]["proportions"].columns.astype(str)
+    )
+    df = summary.modify_proportion_crosstab_with_ci(
+        q6_base_data,
+        experience_income_tables[experience]["uk"]["proportions"],
+        aggregated_responses_column_dict={},
+        aggregated_responses_index_dict=aggregated_responses_income,
+        index_survey_code="profile_gross_household",
+    )
+    experience_income_tables_with_ci[experience] = df
+
+# Combine all experiences in one table
+hp_experience_income_proportions_with_ci = pd.concat(
+    [
+        experience_income_tables_with_ci[experience]["True"]
+        for experience in hp_experience_lookup.keys()
+    ],
+    axis=1,
+)
+hp_experience_income_proportions_with_ci.columns = [
+    "Seen a heat pump",
+    "Been to a home with a heat pump",
+    "Family/close friends/neighbours have a heat pump",
+    "Have had a conversation about installing a heat pump",
+    "At least one experience",
+]
+
+hp_experience_income_proportions_with_ci.reindex(
+    index=[
+        "under £10,000 per year (net)",
+        "£10,000 to £29,999 per year (net)",
+        "£30,000 to £49,999 per year (net)",
+        "£50,000 to £69,999 per year (net)",
+        "£70,000 to £99,999 per year",
+        "£100,000 to £149,999 per year",
+        "£150,000 and over",
+        "Don't know",
+        "Prefer not to answer",
+    ]
+).style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "Proportions of subpopulation (%) (95% CI) who have had prior experience with heat pumps"
+)
+
+# %%
+# Chi-squared contingency test across income groups
+# Each experience question
+
+for experience in hp_experience_lookup.keys():
+    if experience != "hp_experience_any":
+        chi2_stat, p_val, dof, expected = chi2_contingency(
+            experience_income_tables[experience]["uk"]["counts"].drop(
+                index=[
+                    "under £10,000 per year (net)",
+                    "£10,000 to £29,999 per year (net)",
+                    "£30,000 to £49,999 per year (net)",
+                    "£50,000 to £69,999 per year (net)",
+                ],
+                columns="Total",
+            )
+        )
+
+        if p_val < 0.05:
+            print(
+                f"{experience}: A chi-squared test of independence found a significant association between income group and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+        else:
+            print(
+                f"{experience}: A chi-squared test of independence showed no significant relationship between income group and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_3_4_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_3_4_summary.py
@@ -1,0 +1,1029 @@
+# -*- coding: utf-8 -*-
+# ---
+# title: "RQs 3 & 4. Affordability and willingness to borrow"
+# format:
+#   revealjs:
+#     scrollable: true
+#     smaller: true
+#     embed-resources: true
+#     css: styles.css
+#     slide-number: true
+#     footer: "Identifying the next three million heat pump owners: YouGov Survey (RQs 3 & 4)"
+#     center-title-slide: false
+# execute:
+#   enabled: true
+#   echo: false
+#   output: true
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_next_three_million_heat_pump_owners
+#     language: python
+#     name: python3
+# ---
+
+# %%
+## Instructions for rendering
+# 1. Save as a separate .ipynb file
+# 2. Run: quarto render asf_next_three_million_heat_pump_owners/notebooks/[FILE_NAME].ipynb --to revealjs
+
+# %%
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm, chi2_contingency
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.getters import load_data
+
+# %%
+# Load cleaned data
+data, wales_data = load_data.get_analysis_ready_data()
+
+# Get code to full question look-up dictionary
+code_question_lookup = config.get("code_question_lookup")
+
+# %% [markdown]
+# # RQ 3. To what extent, if at all, would installing a heat pump be affordable for UK households, without taking out additional borrowing?
+
+# %% [markdown]
+# ## Question that respondents were asked
+#
+# Upgrading from a fossil fuel boiler to an air source heat pump can cost £12,000 for a typical home. Often smaller, modern homes cost a bit less and larger older homes a bit more. In England, Wales and Scotland, grants are available of up to £7,500 to lower the cost of first-time heat pump installations...  **To what extent, if at all, would installing a heat pump be affordable for your household, without taking out additional borrowing?**
+
+# %% [markdown]
+# **Number of respondents**
+#
+# - Respondents who said they had a heat pump were not asked (n = 135).
+# - From recoding free text responses, however, we identified three responses that indicated that the respondent has a heat pump. As these respondents should not have been asked, we have excluded them from the question base.
+# - Base (unweighted): 6,890
+# - Base (unweighted), after recoding: 6,887
+# - Base (weighted), after recoding: 6,875
+
+# %%
+q5_base_data = data[~(data["PEN_Q2_3_recoded"] == True)]
+
+# %%
+# n = 16 excluded from Wales dataset who have a heat pump
+q5_base_data_wales = wales_data[~(wales_data["PEN_Q2_3_recoded"] == True)]
+
+# %% [markdown]
+# ## RQ 3. Overall
+
+# %% [markdown]
+# Most people said that installing a heat pump without taking out additional borrowing is unaffordable (72%) compared to 18% who said it was affordable and 10% who said they didn't know.
+
+# %%
+# Define response aggregation structure
+q5a_response_aggregation_dict = {
+    "Affordable (net)": [
+        "Very affordable",
+        "Fairly affordable",
+    ],
+    "Unaffordable (net)": [
+        "Very unaffordable",
+        "Fairly unaffordable",
+    ],
+}
+
+# %%
+# Summary dataframe
+q5a_uk = summary.create_single_question_summary_frame(q5_base_data, "PEN_Q5Anew")
+
+# Rename columns
+q5a_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q5a_uk = q5a_uk.drop(index="Not asked").dropna().round(1)
+
+# Combine categories
+for combined_col, source_cols in q5a_response_aggregation_dict.items():
+    q5a_uk.loc[combined_col, :] = q5a_uk.loc[source_cols, :].sum()
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q5_base_data, "PEN_Q5Anew", "weight") * 100
+q5a_uk = q5a_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Add confidence intervals for combined weighted proportions
+affordable_net = summary.weighted_props_ci_combine_categories(
+    q5a_uk,
+    "Very affordable",
+    "Fairly affordable",
+    "Affordable (net)",
+)
+q5a_uk.loc["Affordable (net)", "Lower CI"] = affordable_net["Lower CI"]
+q5a_uk.loc["Affordable (net)", "Upper CI"] = affordable_net["Upper CI"]
+q5a_uk.loc["Affordable (net)", "SE"] = affordable_net["SE"]
+
+not_affordable_net = summary.weighted_props_ci_combine_categories(
+    q5a_uk,
+    "Very unaffordable",
+    "Fairly unaffordable",
+    "Unaffordable (net)",
+)
+q5a_uk.loc["Unaffordable (net)", "Lower CI"] = not_affordable_net["Lower CI"]
+q5a_uk.loc["Unaffordable (net)", "Upper CI"] = not_affordable_net["Upper CI"]
+q5a_uk.loc["Unaffordable (net)", "SE"] = not_affordable_net["SE"]
+
+# Display only select columns
+q5a_uk = q5a_uk.round(1)
+q5a_uk[
+    ["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]
+].style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).format(
+    {
+        "Weighted count": "{:.0f}",
+        "Weighted percentage": "{:.1f}",
+        "Lower CI": "{:.1f}",
+        "Upper CI": "{:.1f}",
+        "SE": "{:.1f}",
+    }
+).set_caption(
+    "To what extent, if at all, would installing a heat pump be affordable for your household, without taking out additional borrowing?"
+)
+
+# %% [markdown]
+# ## RQ 3. By nation
+
+# %% [markdown]
+# The proportions of responses are similar across England, Scotland and Wales.
+
+# %%
+# Individual nation datasets
+q5_base_data_england = q5_base_data[q5_base_data["gornewUK_6"] == True]
+# q5_base_data_wales = q5_base_data[q5_base_data["gornewUK_7"] == True]
+q5_base_data_scotland = q5_base_data[q5_base_data["gornewUK_8"] == True]
+q5_base_data_ni = q5_base_data[q5_base_data["gornewUK_9"] == True]
+
+# Dataset lookup dictionary
+q5_base_data_lookup = {
+    "uk": q5_base_data,
+    "england": q5_base_data_england,
+    "wales": q5_base_data_wales,
+    "scotland": q5_base_data_scotland,
+    "ni": q5_base_data_ni,
+}
+
+# Create comparison table for all nations and UK
+q5a_nations_df, q5a_nations_pct_df = summary.create_nations_summary_tables(
+    q5_base_data, q5_base_data_wales, "PEN_Q5Anew", True
+)
+q5a_nations_pct_df = q5a_nations_pct_df.drop(["Northern Ireland", "UK"])
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q5a_nations_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q5_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q5Anew", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q5a_nations_pct_df_ci = q5a_nations_pct_df.copy(deep=True)
+q5a_nations_pct_df_ci = q5a_nations_pct_df_ci.astype(str)
+
+for index in q5a_nations_pct_df_ci.index:
+    for response in q5a_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q5a_nations_pct_df_ci.loc[index, response] = (
+            f"""{q5a_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+q5a_nations_pct_df_ci = (
+    q5a_nations_pct_df_ci.join(q5a_nations_df["Nation total"])
+    .assign(n=lambda df: df["Nation total"].round(0).astype(int))
+    .drop(columns="Nation total")
+)
+
+q5a_nations_pct_df_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "To what extent, if at all, would installing a heat pump be affordable for your household, without taking out additional borrowing?"
+)
+
+# %% [markdown]
+# ## RQ 1. By tenure
+
+# %% [markdown]
+# Most people across all tenure groups said that a heat pump is unaffordable.
+#
+# Only around a fifth of homeowners (21%) said that a heat pump is affordable without any additional borrowing.
+#
+# Homeowners who own outright have the highest proportion who said the it would be affordable (25%). Homeowners through part-ownership have the highest proportion who said that it would be unaffordable (90%).
+#
+# Interesting trend across tenure categories of proportions that said it would be unaffordable. Similar rates in owners and renters (73% and 74%), but then smaller proportions in other (54%) and neither (62%).
+# - Note that the question was phrased "...affordable **for your household**" so respondents who were in one of the "Neither" or "Other" tenure groups were presumably answering from the point of view of the decision-makers in their household.
+
+# %%
+# Create Q5Anew response breakdown by tenure table for each nation
+q5a_tenure_tables = {}
+for group, base_data in q5_base_data_lookup.items():
+    tables = {}
+    counts_by_tenure, proportions_by_tenure = summary.generate_tenure_breakdown(
+        base_data,
+        "PEN_Q5Anew",
+        q5a_response_aggregation_dict,
+        proportions_axis=1,
+    )
+    tables["counts"] = counts_by_tenure
+    tables["proportions"] = proportions_by_tenure
+
+    q5a_tenure_tables[group] = tables
+
+# %%
+# Plot broad tenure categories comparison
+q5a_tenure_pct_df = (
+    q5a_tenure_tables["uk"]["proportions"]
+    .reindex(index=["Own (net)", "Rent (net)", "Neither (net)", "Other"])
+    .drop(columns=["Total", "Affordable (net)", "Unaffordable (net)"])
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5a_tenure_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+# Aggregated responses to profile_house_tenure
+aggregated_responses_tenure = {
+    "Own (net)": [
+        "Own - outright",
+        "Own - with a mortgage",
+        "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+    ],
+    "Rent (net)": [
+        "Rent - from a private landlord",
+        "Rent - from my local authority",
+        "Rent - from a housing association",
+    ],
+    "Neither (net)": [
+        "Neither - I live with my parents, family or friends but pay some rent to them",
+        "Neither - I live rent-free with my parents, family or friends",
+    ],
+}
+
+q5a_tenure_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5_base_data,
+    proportions_df=q5a_tenure_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5a_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_tenure,
+    index_survey_code="profile_house_tenure",
+).drop(columns="Total")
+
+# %%
+# Display broad tenure categories for UK, proportions with 95% CI
+q5a_tenure_proportions_with_ci_summary = (
+    q5a_tenure_proportions_with_ci.join(q5a_tenure_tables["uk"]["counts"]["Total"])
+    .assign(n=lambda df: df["Total"].round(0).astype(int))
+    .drop(columns="Total")
+)
+
+q5a_tenure_proportions_with_ci_summary.drop(index="Total").style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "To what extent, if at all, would installing a heat pump be affordable for your household, without taking out additional borrowing?"
+)
+
+# %% [markdown]
+# ## RQ 3. By household income
+
+# %% [markdown]
+# The proportion who said it would be affordable increases with increasing income brackets. It increases from 9% of those with household income of <£10k to 62% for >£150k.
+#
+# There is not as clear a trend looking at proportions who said it would be unaffordable.
+
+# %%
+# Create Q5A response breakdown by tenure table for each nation
+q5a_income_tables = {}
+for group, base_data in q5_base_data_lookup.items():
+    tables = {}
+    counts_by_income, proportions_by_income = summary.generate_income_breakdown(
+        base_data,
+        "PEN_Q5Anew",
+        q5a_response_aggregation_dict,
+        proportions_axis=1,
+        aggregate_income=True,
+    )
+    tables["counts"] = counts_by_income
+    tables["proportions"] = proportions_by_income
+
+    q5a_income_tables[group] = tables
+
+# %%
+# 95% confidence intervals for proportions
+
+# Aggregated responses to profile_gross_household
+aggregated_responses_income = {
+    "under £10,000 per year (net)": [
+        "under £5,000 per year",
+        "£5,000 to £9,999 per year",
+    ],
+    "£10,000 to £29,999 per year (net)": [
+        "£10,000 to £14,999 per year",
+        "£15,000 to £19,999 per year",
+        "£20,000 to £24,999 per year",
+        "£25,000 to £29,999 per year",
+    ],
+    "£30,000 to £49,999 per year (net)": [
+        "£30,000 to £34,999 per year",
+        "£35,000 to £39,999 per year",
+        "£40,000 to £44,999 per year",
+        "£45,000 to £49,999 per year",
+    ],
+    "£50,000 to £69,999 per year (net)": [
+        "£50,000 to £59,999 per year",
+        "£60,000 to £69,999 per year",
+    ],
+}
+
+q5a_income_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5_base_data,
+    proportions_df=q5a_income_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5a_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_income,
+    index_survey_code="profile_gross_household",
+).drop(columns="Total")
+
+# %%
+# Plot income bracket comparison table
+q5a_income_pct_df = (
+    q5a_income_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .drop(columns=["Total", "Affordable (net)", "Unaffordable (net)"])
+)
+
+summary.create_stacked_horizontal_bar_chart(
+    q5a_income_pct_df, "Percentage", "Nation", 10, (10, 10)
+).show()
+
+# %% [markdown]
+# Response breakdown by income bracket: Proportions of subpopulation (95% confidence interval) (%)
+
+# %%
+# Show only aggregated income brackets
+q5a_income_proportions_with_ci_summary = (
+    q5a_income_proportions_with_ci.reindex(
+        [
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .join(q5a_income_tables["uk"]["counts"]["Total"].round(0))
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q5a_income_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "To what extent, if at all, would installing a heat pump be affordable for your household, without taking out additional borrowing?"
+)
+
+# %%
+# Chi-squared contingency test across income brackets (net)
+q5a_income_counts_summary = (
+    q5a_income_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+        ]
+    )
+    .drop(columns=["Total", "Affordable (net)", "Unaffordable (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5a_income_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# # RQ 4. How willing, if at all, would UK homeowners be to borrow funds from a mortgage provider/would you be to take out unsecured borrowing (e.g. via a personal loan or credit card) to fund the installation of low carbon heating?
+
+# %% [markdown]
+# ## Questions that respondents were asked
+#
+# - PEN_Q5Bnew. How willing, if at all, would you be to borrow funds from a mortgage provider to fund the installation of low carbon heating (such as heat pumps) in your home? (This could involve extending your existing mortgage or taking out a small additional mortgage)
+# - PEN_Q5Cnew. How willing, if at all, would you be to take out unsecured borrowing (e.g. via a personal loan or credit card) in order to fund the installation of low carbon heating (such as heat pumps) in your home?
+
+# %% [markdown]
+# **Number of respondents**
+# - Respondents who said they had a heat pump or are not homeowners were not asked.
+# - From recoding free text responses, however, we identified three responses that indicated that the respondent has a heat pump. As these respondents should not have been asked, we have excluded them from the question base.
+# - Base (unweighted): 4,507
+# - Base (unweighted), after recoding: 4,506
+# - Base (weighted), after recoding: 4,173
+
+# %%
+q5b_base_data = data[
+    ~(data["PEN_Q2_3_recoded"] == True)
+    & (
+        (data["profile_house_tenure"] == "Own - outright")
+        | (data["profile_house_tenure"] == "Own - with a mortgage")
+        | (
+            data["profile_house_tenure"]
+            == "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)"
+        )
+    )
+]
+
+# %%
+q5b_base_data_wales = wales_data[
+    ~(wales_data["PEN_Q2_3_recoded"] == True)
+    & (
+        (wales_data["profile_house_tenure"] == "Own - outright")
+        | (wales_data["profile_house_tenure"] == "Own - with a mortgage")
+        | (
+            wales_data["profile_house_tenure"]
+            == "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)"
+        )
+    )
+]
+
+# %%
+# Aggregated responses to PEN_Q5Bnew and PEN_Q5Cnew
+q5b_q5c_response_aggregation_dict = {
+    "Willing (net)": [
+        "Very willing",
+        "Fairly willing",
+    ],
+    "Not willing (net)": [
+        "Not at all willing",
+        "Not very willing",
+    ],
+}
+
+# %% [markdown]
+# ## RQ 4. Overall: Via mortgage provider
+
+# %% [markdown]
+# Most people (89%) are not willing to take out additional borrowing from a mortgage provider to fund the installation of low carbon heating system. Only 7% of people are willing.
+
+# %%
+# Summary dataframe
+q5b_uk = summary.create_single_question_summary_frame(q5b_base_data, "PEN_Q5Bnew")
+
+# Rename columns
+q5b_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q5b_uk = q5b_uk.drop(index="Not asked").dropna().round(1)
+
+# Combine categories
+for combined_col, source_cols in q5b_q5c_response_aggregation_dict.items():
+    q5b_uk.loc[combined_col, :] = q5b_uk.loc[source_cols, :].sum()
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q5b_base_data, "PEN_Q5Bnew", "weight") * 100
+q5b_uk = q5b_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Add confidence intervals for combined weighted proportions
+willing_net = summary.weighted_props_ci_combine_categories(
+    q5b_uk,
+    "Very willing",
+    "Fairly willing",
+    "Willing (net)",
+)
+q5b_uk.loc["Willing (net)", "Lower CI"] = willing_net["Lower CI"]
+q5b_uk.loc["Willing (net)", "Upper CI"] = willing_net["Upper CI"]
+q5b_uk.loc["Willing (net)", "SE"] = willing_net["SE"]
+
+not_willing_net = summary.weighted_props_ci_combine_categories(
+    q5b_uk,
+    "Not at all willing",
+    "Not very willing",
+    "Not willing (net)",
+)
+q5b_uk.loc["Not willing (net)", "Lower CI"] = not_willing_net["Lower CI"]
+q5b_uk.loc["Not willing (net)", "Upper CI"] = not_willing_net["Upper CI"]
+q5b_uk.loc["Not willing (net)", "SE"] = not_willing_net["SE"]
+
+# Display only select columns
+q5b_uk = q5b_uk.round(1)
+q5b_uk[
+    ["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]
+].style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How willing, if at all, would you be to borrow funds from a mortgage provider to fund the installation of low carbon heating (such as heat pumps) in your home?"
+).format(
+    {
+        "Weighted count": "{:.0f}",
+        "Weighted percentage": "{:.1f}",
+        "Lower CI": "{:.1f}",
+        "Upper CI": "{:.1f}",
+        "SE": "{:.1f}",
+    }
+)
+
+# %% [markdown]
+# ## RQ 4. Overall: Via unsecured borrowing
+
+# %% [markdown]
+# Most people (93%) are not willing to take out unsecured borrowing to fund the installation of low carbon heating system. This proportion is slightly higher than the proportion not willing to borrow via a mortgage provider (89%).
+# Only 4% are willing, which is slightly lower than the proportion for borrowing via a mortgage provider (7%).
+
+# %%
+# Summary dataframe
+q5c_uk = summary.create_single_question_summary_frame(q5b_base_data, "PEN_Q5Cnew")
+
+# Rename columns
+q5c_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q5c_uk = q5c_uk.drop(index="Not asked").dropna().round(1)
+
+# Combine categories
+for combined_col, source_cols in q5b_q5c_response_aggregation_dict.items():
+    q5c_uk.loc[combined_col, :] = q5c_uk.loc[source_cols, :].sum()
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q5b_base_data, "PEN_Q5Bnew", "weight") * 100
+q5c_uk = q5c_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Add confidence intervals for combined weighted proportions
+willing_net = summary.weighted_props_ci_combine_categories(
+    q5c_uk,
+    "Very willing",
+    "Fairly willing",
+    "Willing (net)",
+)
+q5c_uk.loc["Willing (net)", "Lower CI"] = willing_net["Lower CI"]
+q5c_uk.loc["Willing (net)", "Upper CI"] = willing_net["Upper CI"]
+q5c_uk.loc["Willing (net)", "SE"] = willing_net["SE"]
+
+not_willing_net = summary.weighted_props_ci_combine_categories(
+    q5c_uk,
+    "Not at all willing",
+    "Not very willing",
+    "Not willing (net)",
+)
+q5c_uk.loc["Not willing (net)", "Lower CI"] = not_willing_net["Lower CI"]
+q5c_uk.loc["Not willing (net)", "Upper CI"] = not_willing_net["Upper CI"]
+q5c_uk.loc["Not willing (net)", "SE"] = not_willing_net["SE"]
+
+# Display only select columns
+q5c_uk = q5c_uk.round(1)
+q5c_uk[
+    ["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]
+].style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How willing, if at all, would you be to take out unsecured borrowing (e.g. via a personal loan or credit card) in order to fund the installation of low carbon heating (such as heat pumps) in your home?"
+).format(
+    {
+        "Weighted count": "{:.0f}",
+        "Weighted percentage": "{:.1f}",
+        "Lower CI": "{:.1f}",
+        "Upper CI": "{:.1f}",
+        "SE": "{:.1f}",
+    }
+)
+
+# %% [markdown]
+# ## RQ 4. By nation: Via mortgage provider
+
+# %% [markdown]
+# The proportions of responses are similar across England, Scotland and Wales, with the proportion of people who aren't willing being slightly higher in Wales (93% vs. 89% in England and 88% in Scotland).
+
+# %%
+# Individual nation datasets
+q5b_base_data_england = q5b_base_data[q5b_base_data["gornewUK_6"] == True]
+# q5b_base_data_wales = q5b_base_data[q5b_base_data["gornewUK_7"] == True]
+q5b_base_data_scotland = q5b_base_data[q5b_base_data["gornewUK_8"] == True]
+q5b_base_data_ni = q5b_base_data[q5b_base_data["gornewUK_9"] == True]
+
+# Dataset lookup dictionary
+q5b_base_data_lookup = {
+    "uk": q5b_base_data,
+    "england": q5b_base_data_england,
+    "wales": q5b_base_data_wales,
+    "scotland": q5b_base_data_scotland,
+    "ni": q5b_base_data_ni,
+}
+
+# Create comparison table for all nations and UK
+q5b_nations_df, q5b_nations_pct_df = summary.create_nations_summary_tables(
+    q5b_base_data, q5b_base_data_wales, "PEN_Q5Bnew", True
+)
+q5b_nations_pct_df = q5b_nations_pct_df.drop("Northern Ireland")
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q5b_nations_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q5b_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q5Bnew", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q5b_nations_pct_df_ci = q5b_nations_pct_df.copy(deep=True)
+q5b_nations_pct_df_ci = q5b_nations_pct_df_ci.astype(str)
+
+for index in q5b_nations_pct_df_ci.index:
+    for response in q5b_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q5b_nations_pct_df_ci.loc[index, response] = (
+            f"""{q5b_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+q5b_nations_pct_df_ci = (
+    q5b_nations_pct_df_ci.join(q5b_nations_df["Nation total"])
+    .assign(n=lambda df: df["Nation total"].round(0).astype(int))
+    .drop(columns="Nation total")
+)
+
+q5b_nations_pct_df_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How willing, if at all, would you be to borrow funds from a mortgage provider to fund the installation of low carbon heating (such as heat pumps) in your home?"
+)
+
+# %% [markdown]
+# ## RQ 4. By nation: Unsecured borrowing
+
+# %% [markdown]
+# The proportions of responses are similar across England, Scotland and Wales.
+
+# %%
+# Create comparison table for all nations and UK
+q5c_nations_df, q5c_nations_pct_df = summary.create_nations_summary_tables(
+    q5b_base_data, q5b_base_data_wales, "PEN_Q5Cnew", True
+)
+q5c_nations_pct_df = q5c_nations_pct_df.drop("Northern Ireland")
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q5c_nations_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %% [markdown]
+# Response breakdown by nation: Proportions of subpopulation (95% confidence interval) (%)
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q5b_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q5Cnew", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q5c_nations_pct_df_ci = q5c_nations_pct_df.copy(deep=True)
+q5c_nations_pct_df_ci = q5c_nations_pct_df_ci.astype(str)
+
+for index in q5c_nations_pct_df_ci.index:
+    for response in q5c_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q5c_nations_pct_df_ci.loc[index, response] = (
+            f"""{q5c_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+q5c_nations_pct_df_ci = (
+    q5c_nations_pct_df_ci.join(q5b_nations_df["Nation total"])
+    .assign(n=lambda df: df["Nation total"].round(0).astype(int))
+    .drop(columns="Nation total")
+)
+
+q5c_nations_pct_df_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How willing, if at all, would you be to take out unsecured borrowing (e.g. via a personal loan or credit card) in order to fund the installation of low carbon heating (such as heat pumps) in your home?"
+)
+
+# %% [markdown]
+# ## RQ 4. By household income: Via mortgage provider
+
+# %% [markdown]
+# Willingness to borrow funds via mortgage provider generally increases with income bracket. This proportion is 5% for those with household income under £10k and increases to 16% of those earning over £150k.
+
+# %%
+# Create Q5B response breakdown by tenure table for each nation
+q5b_income_tables = {}
+for group, base_data in q5b_base_data_lookup.items():
+    tables = {}
+    counts_by_income, proportions_by_income = summary.generate_income_breakdown(
+        base_data,
+        "PEN_Q5Bnew",
+        q5b_q5c_response_aggregation_dict,
+        proportions_axis=1,
+        aggregate_income=True,
+    )
+    tables["counts"] = counts_by_income
+    tables["proportions"] = proportions_by_income
+
+    q5b_income_tables[group] = tables
+
+# %%
+# 95% confidence intervals for proportions
+q5b_income_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5b_base_data,
+    proportions_df=q5b_income_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5b_q5c_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_income,
+    index_survey_code="profile_gross_household",
+).drop(columns="Total")
+
+# %%
+# Plot income bracket comparison table
+q5b_income_pct_df = (
+    q5b_income_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .drop(columns=["Total", "Willing (net)", "Not willing (net)"])
+)
+summary.create_stacked_horizontal_bar_chart(
+    q5b_income_pct_df, "Percentage", "Income", 10, (10, 10)
+).show()
+
+# %% [markdown]
+# Response breakdown by income bracket: Proportions of subpopulation (95% confidence interval) (%)
+
+# %%
+# Show only aggregated income brackets
+q5b_income_proportions_with_ci_summary = (
+    q5b_income_proportions_with_ci.reindex(
+        [
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .join(q5a_income_tables["uk"]["counts"]["Total"].round(0))
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q5b_income_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How willing, if at all, would you be to borrow funds from a mortgage provider to fund the installation of low carbon heating (such as heat pumps) in your home?"
+)
+
+# %%
+# Chi-squared contingency test across income brackets (net)
+q5b_income_counts_summary = (
+    q5b_income_tables["uk"]["counts"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+        ]
+    )
+    .drop(columns=["Total", "Willing (net)", "Not willing (net)"])
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5b_income_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between income group subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+
+# %% [markdown]
+# ## RQ 4. By household income: Unsecured borrowing
+
+# %% [markdown]
+# Willingness to borrow funds via unsecured borrowing generally increases with income bracket. This proportion is 1% for those with household income under £10k and increases to 14% of those earning over £150k. These percentages are smaller in comparison to the mortgage provider question.
+
+# %%
+# Create Q5C response breakdown by tenure table for each nation
+q5c_income_tables = {}
+for group, base_data in q5b_base_data_lookup.items():
+    tables = {}
+    counts_by_income, proportions_by_income = summary.generate_income_breakdown(
+        base_data,
+        "PEN_Q5Cnew",
+        q5b_q5c_response_aggregation_dict,
+        proportions_axis=1,
+        aggregate_income=True,
+    )
+    tables["counts"] = counts_by_income
+    tables["proportions"] = proportions_by_income
+
+    q5c_income_tables[group] = tables
+
+# %%
+# 95% confidence intervals for proportions
+q5c_income_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=q5b_base_data,
+    proportions_df=q5c_income_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5b_q5c_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_income,
+    index_survey_code="profile_gross_household",
+).drop(columns="Total")
+
+# %%
+# Plot income bracket comparison table
+q5c_income_pct_df = (
+    q5c_income_tables["uk"]["proportions"]
+    .reindex(
+        index=[
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .drop(columns=["Total", "Willing (net)", "Not willing (net)"])
+)
+summary.create_stacked_horizontal_bar_chart(
+    q5c_income_pct_df, "Percentage", "Income bracket", 10, (10, 10)
+).show()
+
+# %%
+# Show only aggregated income brackets
+q5c_income_proportions_with_ci_summary = (
+    q5c_income_proportions_with_ci.reindex(
+        [
+            "under £10,000 per year (net)",
+            "£10,000 to £29,999 per year (net)",
+            "£30,000 to £49,999 per year (net)",
+            "£50,000 to £69,999 per year (net)",
+            "£70,000 to £99,999 per year",
+            "£100,000 to £149,999 per year",
+            "£150,000 and over",
+            "Don't know",
+            "Prefer not to answer",
+        ]
+    )
+    .join(q5a_income_tables["uk"]["counts"]["Total"].round(0))
+    .rename(columns={"Total": "n"})
+    .assign(n=lambda df: df["n"].astype(int))
+)
+
+q5c_income_proportions_with_ci_summary.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How willing, if at all, would you be to take out unsecured borrowing (e.g. via a personal loan or credit card) in order to fund the installation of low carbon heating (such as heat pumps) in your home?"
+)
+
+# %%
+# Exploratory
+
+# %%
+# # Affordability by age
+# df = pd.crosstab(
+#     index=q5_base_data["profile_julesage"],
+#     columns=q5_base_data["PEN_Q5Anew"],
+#     values=q5_base_data["weight"],
+#     aggfunc="sum",
+#     normalize="index",
+# )
+# df["Total"] = df.sum(axis=1)
+# df = (df * 100).round(1)
+
+
+# for combined_col, source_cols in q5a_response_aggregation_dict.items():
+#     df[combined_col] = df[source_cols].sum(axis=1)
+
+# df
+
+# %%
+# # Willingness to borrow (mortgage) by main benefit
+# df = pd.crosstab(
+#     index=q5_base_data["PEN_Q14"],
+#     columns=q5_base_data["PEN_Q5Bnew"],
+#     values=q5_base_data["weight"],
+#     aggfunc="sum",
+#     normalize="index",
+# )
+# df["Total"] = df.sum(axis=1)
+# df = (df * 100).round(1)
+
+
+# for combined_col, source_cols in q5b_q5c_response_aggregation_dict.items():
+#     df[combined_col] = df[source_cols].sum(axis=1)
+
+# df
+
+# %%
+# # Willingness to borrow (unsecured) by main benefit
+# df = pd.crosstab(
+#     index=q5_base_data["PEN_Q14"],
+#     columns=q5_base_data["PEN_Q5Cnew"],
+#     values=q5_base_data["weight"],
+#     aggfunc="sum",
+#     normalize="index",
+# )
+# df["Total"] = df.sum(axis=1)
+# df = (df * 100).round(1)
+
+
+# for combined_col, source_cols in q5b_q5c_response_aggregation_dict.items():
+#     df[combined_col] = df[source_cols].sum(axis=1)
+
+# df

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_6_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_6_summary.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+# ---
+# title: "RQ 6. How desirable is buying a house that has a heat pump be for UK households?"
+# format:
+#   revealjs:
+#     scrollable: true
+#     smaller: true
+#     embed-resources: true
+#     css: styles.css
+#     slide-number: true
+#     footer: "RQ 6. How desirable is buying a house that has a heat pump be for UK households?"
+#     center-title-slide: false
+# execute:
+#   enabled: true
+#   echo: false
+#   output: true
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_next_three_million_heat_pump_owners
+#     language: python
+#     name: python3
+# ---
+
+# %%
+## Instructions for rendering
+# 1. Save as a separate .ipynb file
+# 2. Run: quarto render asf_next_three_million_heat_pump_owners/notebooks/[FILE_NAME].ipynb --to revealjs
+
+# %%
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm, chi2_contingency
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.getters import load_data
+
+# %%
+# Load cleaned data
+data, wales_data = load_data.get_analysis_ready_data()
+
+# Get code to full question look-up dictionary
+code_question_lookup = config.get("code_question_lookup")
+
+# %% [markdown]
+# ## Question that respondents were asked
+#
+# How desirable, if at all, would buying a house that has a heat pump be for you?
+
+# %% [markdown]
+# **Number of respondents**
+# - All respondents were asked.
+# - Base: 7,025
+
+# %%
+base_data = data.copy(deep=True)
+
+# %%
+base_data_wales = wales_data.copy(deep=True)
+
+# %% [markdown]
+# ## RQ 6. Overall
+
+# %% [markdown]
+# A greater proportion of respondents said a house with a heat pump would not be desirable (41%) rather than desirable (36%). Almost a quarter (23%) said that they didn't know.
+
+# %%
+# Response aggregation dict
+q5d_response_aggregation_dict = {
+    "Desirable (net)": ["Very desirable", "Somewhat desirable"],
+    "Not desirable (net)": ["Not at all desirable", "Not very desirable"],
+}
+
+# %%
+# Summary dataframe
+q5d_uk = summary.create_single_question_summary_frame(base_data, "PEN_Q5Dnew")
+
+# Rename columns
+q5d_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Combine categories
+for combined_col, source_cols in q5d_response_aggregation_dict.items():
+    q5d_uk.loc[combined_col, :] = q5d_uk.loc[source_cols, :].sum()
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(base_data, "PEN_Q5Dnew", "weight") * 100
+q5d_uk = q5d_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Add confidence intervals for combined weighted proportions
+desirable_net = summary.weighted_props_ci_combine_categories(
+    q5d_uk,
+    "Somewhat desirable",
+    "Very desirable",
+    "Desirable (net)",
+)
+q5d_uk.loc["Desirable (net)", "Lower CI"] = desirable_net["Lower CI"]
+q5d_uk.loc["Desirable (net)", "Upper CI"] = desirable_net["Upper CI"]
+q5d_uk.loc["Desirable (net)", "SE"] = desirable_net["SE"]
+
+not_desirable_net = summary.weighted_props_ci_combine_categories(
+    q5d_uk,
+    "Not very desirable",
+    "Not at all desirable",
+    "Not desirable (net)",
+)
+q5d_uk.loc["Not desirable (net)", "Lower CI"] = not_desirable_net["Lower CI"]
+q5d_uk.loc["Not desirable (net)", "Upper CI"] = not_desirable_net["Upper CI"]
+q5d_uk.loc["Not desirable (net)", "SE"] = not_desirable_net["SE"]
+
+# Display only select columns
+q5d_uk = q5d_uk.round(1)
+q5d_uk[
+    ["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]
+].style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).format(
+    {
+        "Weighted count": "{:.0f}",
+        "Weighted percentage": "{:.1f}",
+        "Lower CI": "{:.1f}",
+        "Upper CI": "{:.1f}",
+        "SE": "{:.1f}",
+    }
+).set_caption(
+    "How desirable, if at all, would buying a house that has a heat pump be for you?"
+)
+
+# %% [markdown]
+# ## RQ 6. By nation
+
+# %% [markdown]
+# The proportion breakdown of responses is similar across England, Scotland and Wales.
+
+# %%
+# Individual nation datasets
+base_data_england = base_data[base_data["gornewUK_6"] == True]
+# base_data_wales = base_data[base_data["gornewUK_7"] == True]
+base_data_scotland = base_data[base_data["gornewUK_8"] == True]
+base_data_ni = base_data[base_data["gornewUK_9"] == True]
+
+# Dataset lookup dictionary
+base_data_lookup = {
+    "uk": base_data,
+    "england": base_data_england,
+    "wales": base_data_wales,
+    "scotland": base_data_scotland,
+    "ni": base_data_ni,
+}
+
+# Create comparison table for all nations and UK
+q5d_nations_df, q5d_nations_pct_df = summary.create_nations_summary_tables(
+    base_data, base_data_wales, "PEN_Q5Dnew", False
+)
+q5d_nations_pct_df = q5d_nations_pct_df.drop("Northern Ireland")
+
+# %%
+summary.create_stacked_horizontal_bar_chart(
+    q5d_nations_pct_df, "Percentage", "Nation", 10, (10, 5)
+).show()
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q5Dnew", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q5d_nations_pct_df_ci = q5d_nations_pct_df.copy(deep=True)
+q5d_nations_pct_df_ci = q5d_nations_pct_df_ci.astype(str)
+
+for index in q5d_nations_pct_df_ci.index:
+    for response in q5d_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q5d_nations_pct_df_ci.loc[index, response] = (
+            f"""{q5d_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+q5d_nations_pct_df_ci = (
+    q5d_nations_pct_df_ci.join(q5d_nations_df["Nation total"])
+    .assign(**{"Nation total": lambda df: df["Nation total"].round(0).astype(int)})
+    .rename(columns={"Nation total": "n"})
+)
+
+q5d_nations_pct_df_ci.style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How desirable, if at all, would buying a house that has a heat pump be for you?"
+)
+
+# %% [markdown]
+# ## RQ 6. By tenure
+
+# %% [markdown]
+# People who live with family/friends rent-free have the highest proportion who said that buying a house with a heat pump would be desirable (48%). Those renting from their local authority have the lowest (28%).
+#
+# People who own their homes outright have the highest proportion of people who said it would not be desirable (48%, just under half).
+#
+# For the renters (net) tenure group, the proportion of people who said desirable vs. not desirable are roughly the same (36% vs. 38%). For homeowners (net), however, the proportion who said not desirable (45%) is greater than that who said desirable (34%). The opposite is true for the neither/other group where more people said desirable (43%) than undesirable (27%).
+
+# %%
+# Create Q5D response breakdown by tenure table for each nation
+q5d_tenure_tables = {}
+for group, base_data_nation in base_data_lookup.items():
+    tables = {}
+    counts_by_tenure, proportions_by_tenure = summary.generate_tenure_breakdown(
+        base_data_nation,
+        "PEN_Q5Dnew",
+        q5d_response_aggregation_dict,
+        proportions_axis=1,
+    )
+    tables["counts"] = counts_by_tenure
+    tables["proportions"] = proportions_by_tenure
+
+    q5d_tenure_tables[group] = tables
+
+# %%
+# Plot broad tenure categories comparison
+q5d_tenure_pct_df = (
+    q5d_tenure_tables["uk"]["proportions"]
+    .reindex(index=["Own (net)", "Rent (net)", "Neither (net)", "Other"])
+    .drop(columns=["Total", "Desirable (net)", "Not desirable (net)"])
+)
+summary.create_stacked_horizontal_bar_chart(
+    q5d_tenure_pct_df, "Percentage", "Tenure", 10, (10, 5)
+).show()
+
+# %%
+# 95% confidence intervals for proportions
+
+# Aggregated responses to profile_house_tenure
+aggregated_responses_tenure = {
+    "Own (net)": [
+        "Own - outright",
+        "Own - with a mortgage",
+        "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)",
+    ],
+    "Rent (net)": [
+        "Rent - from a private landlord",
+        "Rent - from my local authority",
+        "Rent - from a housing association",
+    ],
+    "Neither (net)": [
+        "Neither - I live with my parents, family or friends but pay some rent to them",
+        "Neither - I live rent-free with my parents, family or friends",
+    ],
+}
+
+q5d_tenure_proportions_with_ci = summary.modify_proportion_crosstab_with_ci(
+    base_data=base_data,
+    proportions_df=q5d_tenure_tables["uk"]["proportions"],
+    aggregated_responses_column_dict=q5d_response_aggregation_dict,
+    aggregated_responses_index_dict=aggregated_responses_tenure,
+    index_survey_code="profile_house_tenure",
+).drop(columns="Total")
+
+# %%
+# Display broad tenure categories for UK, proportions with 95% CI
+q5d_tenure_proportions_with_ci_summary = (
+    q5d_tenure_proportions_with_ci.join(q5d_tenure_tables["uk"]["counts"]["Total"])
+    .assign(Total=lambda df: df["Total"].round(0).astype(int))
+    .rename(columns={"Total": "n"})
+)
+
+q5d_tenure_proportions_with_ci_summary.drop(index="Total").style.set_table_styles(
+    [
+        {"selector": "td", "props": [("font-size", "18px")]},
+        {"selector": "th", "props": [("font-size", "18px"), ("text-align", "left")]},
+    ]
+).set_caption(
+    "How desirable, if at all, would buying a house that has a heat pump be for you?"
+)
+
+# %%
+# Chi-squared contingency test across tenure
+q5d_tenure_counts_summary = q5d_tenure_tables["uk"]["counts"].drop(
+    index=["Own (net)", "Rent (net)", "Neither (net)", "Total"],
+    columns=["Total", "Desirable (net)", "Not desirable (net)"],
+)
+chi2_stat, p_val, dof, expected = chi2_contingency(q5d_tenure_counts_summary)
+
+if p_val < 0.05:
+    print(
+        f"A chi-squared test of independence found a significant association between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )
+else:
+    print(
+        f"A chi-squared test of independence showed no significant relationship between tenure subpopulations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+    )

--- a/asf_next_three_million_heat_pump_owners/notebooks/rq_7_summary.py
+++ b/asf_next_three_million_heat_pump_owners/notebooks/rq_7_summary.py
@@ -1,0 +1,701 @@
+# -*- coding: utf-8 -*-
+# ---
+# title: "RQ 7. Perceived barriers and benefits"
+# format:
+#   revealjs:
+#     scrollable: true
+#     smaller: true
+#     embed-resources: true
+#     css: styles.css
+#     slide-number: true
+#     footer: "Identifying the next three million heat pump owners: YouGov Survey (RQ 7)"
+#     center-title-slide: false
+# execute:
+#   enabled: true
+#   echo: false
+#   output: true
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_next_three_million_heat_pump_owners
+#     language: python
+#     name: python3
+# ---
+
+# %%
+## Instructions for rendering
+# 1. Save as a separate .ipynb file
+# 2. Run: quarto render asf_next_three_million_heat_pump_owners/notebooks/[FILE_NAME].ipynb --to revealjs
+
+# %%
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm, chi2_contingency
+
+from asf_next_three_million_heat_pump_owners import config
+from asf_next_three_million_heat_pump_owners.utils import summary
+from asf_next_three_million_heat_pump_owners.getters import load_data
+
+# %%
+# Load cleaned data
+data, wales_data = load_data.get_analysis_ready_data()
+
+# Get code to full question look-up dictionary
+code_question_lookup = config.get("code_question_lookup")
+
+# %% [markdown]
+# # RQ 7. What barriers and benefits do people foresee when it comes to installing a heat pump?
+
+# %% [markdown]
+# ## Questions that respondents were asked
+#
+# **Barriers**
+# - PEN_Q11. Which, if any, of the following factors do you think would prevent you from installing a heat pump in your home? (Please select all that apply. If there is no specific barrier towards installing a heat pump in your home, please select the "Not applicable" option)
+# - PEN_Q12. Which ONE of the following factors do you think would prevent you the MOST from installing a heat pump in your home
+#
+#
+# **Benefits**
+# - PEN_Q13. Which, if any, of the following benefits about heat pumps is likely to encourage you to install a heat pump in your home in the future? (Please select all that apply. If you would never get a heat pump installed in your home, please select the "Not applicable" option)
+# - PEN_Q14. Which ONE of the following benefits about heat pumps is MOST likely to encourage you to install a heat pump in your home in the future?
+
+# %% [markdown]
+# ## Number of respondents
+# - Respondents who said they had a heat pump or are not homeowners were not asked.
+# - From recoding free text responses, however, we identified three responses that indicated that the respondent has a heat pump. As these respondents should not have been asked, we have excluded them from the question base.
+# - Base (unweighted): 4,507
+# - Base (unweighted), after recoding: 4,506
+# - Base (weighted), after recoding: 4,173
+
+# %%
+q11_base_data = data[
+    ~(data["PEN_Q2_3_recoded"] == True)
+    & (
+        (data["profile_house_tenure"] == "Own - outright")
+        | (data["profile_house_tenure"] == "Own - with a mortgage")
+        | (
+            data["profile_house_tenure"]
+            == "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)"
+        )
+    )
+]
+
+# %%
+q11_base_data_wales = wales_data[
+    ~(wales_data["PEN_Q2_3_recoded"] == True)
+    & (
+        (wales_data["profile_house_tenure"] == "Own - outright")
+        | (wales_data["profile_house_tenure"] == "Own - with a mortgage")
+        | (
+            wales_data["profile_house_tenure"]
+            == "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)"
+        )
+    )
+]
+
+# %%
+# Individual nation datasets
+q11_base_data_england = q11_base_data[q11_base_data["gornewUK_6"] == True]
+# q11_base_data_wales = q11_base_data[q11_base_data["gornewUK_7"] == True]
+q11_base_data_scotland = q11_base_data[q11_base_data["gornewUK_8"] == True]
+q11_base_data_ni = q11_base_data[q11_base_data["gornewUK_9"] == True]
+
+# Dataset lookup dictionary
+q11_base_data_lookup = {
+    "uk": q11_base_data,
+    "england": q11_base_data_england,
+    "wales": q11_base_data_wales,
+    "scotland": q11_base_data_scotland,
+    "ni": q11_base_data_ni,
+}
+
+# %% [markdown]
+# ## RQ 7. UK and by nation: Barriers (Select all that apply)
+
+# %% [markdown]
+# The most common barrier across E/S/W and UK overall is "Too expensive to install", with 64% of people in the UK selecting this. The next most popular barriers that are not related to being happy with their current system are not being convinced by the technology (37%) and not thinking it makes financial sense as an investment (34%).
+#
+# A large portion of respondents selected barriers related to not seeing the need to change their current system (47% saying they will stick with the current system until it needs replacing, and 46% saying they are happy with their current system and see no reason to change).
+#
+# *The proportion of responses are similar across nations.*
+#
+
+# %%
+barrier_options = [
+    barrier for barrier in code_question_lookup.keys() if "Q11_" in barrier
+]
+
+# %%
+multi_barrier_tables = {}
+for barrier in barrier_options:
+    if barrier == "PEN_Q11_collapsed":
+        pass
+    else:
+        counts, proportions = summary.create_nations_summary_tables(
+            q11_base_data, q11_base_data_wales, barrier, False
+        )
+        counts = counts.drop("Northern Ireland")
+        proportions = proportions.drop("Northern Ireland")
+        multi_barrier_tables[barrier] = {"counts": counts, "proportions": proportions}
+
+# %%
+# Summarise all barriers
+multi_barrier_counts = pd.DataFrame()
+multi_barrier_proportions = pd.DataFrame()
+for barrier in barrier_options:
+    if barrier == "PEN_Q11_collapsed":
+        pass
+    else:
+        multi_barrier_counts = pd.concat(
+            [multi_barrier_counts, multi_barrier_tables[barrier]["counts"]["True"]],
+            axis=1,
+        )
+        multi_barrier_proportions = pd.concat(
+            [
+                multi_barrier_proportions,
+                multi_barrier_tables[barrier]["proportions"]["True"],
+            ],
+            axis=1,
+        )
+
+barrier_column_names = []
+for barrier in barrier_options:
+    if barrier == "PEN_Q11_collapsed":
+        pass
+    else:
+        barrier_column_names.append(
+            f"{code_question_lookup.get(barrier).split(':')[1]}"
+        )
+
+for df in [multi_barrier_counts, multi_barrier_proportions]:
+    df.columns = barrier_column_names
+
+# %%
+multi_barrier_df = multi_barrier_proportions.reset_index().rename(
+    columns={"index": "Nation"}
+)
+multi_barrier_df_long = multi_barrier_df.melt(
+    id_vars="Nation", var_name="Barrier", value_name="Percentage"
+)
+
+sorted_order = multi_barrier_df_long[
+    multi_barrier_df_long["Nation"] == "England"
+].sort_values("Percentage", ascending=False)["Barrier"]
+
+plt.figure(figsize=(12, 10))
+ax = sns.barplot(
+    data=multi_barrier_df_long,
+    y="Barrier",
+    x="Percentage",
+    hue="Nation",
+    order=sorted_order,
+)
+ax.xaxis.grid(True, linestyle="-", alpha=0.3)
+plt.xlabel("Percentage (%)")
+plt.ylabel("Barrier")
+plt.legend(title="Nation")
+plt.tight_layout()
+plt.show()
+
+# %%
+# Compile 95% ci tables for each barrier and each nation
+barrier_proportions_ci = {}
+for nation, nation_data in q11_base_data_lookup.items():
+    nation_tables = {}
+    for barrier in barrier_options:
+        if barrier != "PEN_Q11_collapsed":
+            nation_tables[barrier] = (
+                summary.weighted_props_ci(nation_data, barrier, "weight") * 100
+            ).round(1)
+    barrier_proportions_ci[nation] = nation_tables
+
+# Modify original nation comparison tables with lower and upper CI values
+multi_barrier_proportions_with_ci = multi_barrier_proportions.copy(deep=True)
+multi_barrier_proportions_with_ci = multi_barrier_proportions_with_ci.astype(str)
+
+for barrier in barrier_options:
+    if barrier != "PEN_Q11_collapsed":
+        for index in multi_barrier_proportions_with_ci.index:
+            lower = barrier_proportions_ci[index.lower()][barrier].loc[
+                "True", "Lower CI"
+            ]
+            upper = barrier_proportions_ci[index.lower()][barrier].loc[
+                "True", "Upper CI"
+            ]
+
+            multi_barrier_proportions_with_ci.loc[
+                index, code_question_lookup.get(barrier).split(":")[1]
+            ] = f"""{multi_barrier_proportions_with_ci.loc[index, code_question_lookup.get(barrier).split(':')[1]]} ({lower}-{upper})"""
+
+# %%
+multi_barrier_proportions_with_ci.T
+
+# %%
+# Chi-squared contingency test across nations
+# Each barrier question
+
+for barrier in barrier_options:
+    if barrier != "PEN_Q11_collapsed":
+        chi2_stat, p_val, dof, expected = chi2_contingency(
+            multi_barrier_tables[barrier]["counts"].drop(
+                index="UK", columns="Nation total"
+            )
+        )
+
+        if p_val < 0.05:
+            print(
+                f"{barrier}: A chi-squared test of independence found a significant association between nations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+        else:
+            print(
+                f"{barrier}: A chi-squared test of independence showed no significant relationship between nations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+
+# %% [markdown]
+# ## RQ 7. UK: Main barrier
+
+# %% [markdown]
+# The most common factor that would prevent people from installing a heat pump is expense (32% chose "Too expensive to install" as the factor that would prevent them the most). This is followed by being happy with their current system (13%) and not being convinced that technology can heat their home (12%).
+#
+#
+
+# %%
+# Summary dataframe
+q12_uk = summary.create_single_question_summary_frame(q11_base_data, "PEN_Q12")
+
+# Rename columns
+q12_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q12_uk = q12_uk.drop(index="Not asked").dropna().round(1)
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q11_base_data, "PEN_Q12", "weight") * 100
+q12_uk = q12_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Display only select columns
+q12_uk = q12_uk.round(1)
+q12_uk[["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]]
+
+# %% [markdown]
+# ## RQ 7. By nation: Main barrier
+
+# %% [markdown]
+# The top barriers are fairly similar across nations. Top three main barriers:
+# - England: Too expensive, happy with current system, current system doesn't need replacing
+# - Scotland: Too expensive, happy with current system, not appropriate for my property
+# - Wales: Too expensive, not convinced of technology, happy with current system
+
+# %%
+# Create comparison table for all nations and UK
+q12_nations_df, q12_nations_pct_df = summary.create_nations_summary_tables(
+    q11_base_data, q11_base_data_wales, "PEN_Q12", True
+)
+q12_nations_pct_df = q12_nations_pct_df.drop("Northern Ireland")
+
+# %%
+# Add rank columns for comparing ranks across nations
+q12_nations_pct_df_compare = q12_nations_pct_df.T.drop(columns="UK").sort_values(
+    by="England", ascending=False
+)
+for nation in ["England", "Scotland", "Wales"]:
+    q12_nations_pct_df_compare[f"{nation} rank"] = (
+        q12_nations_pct_df_compare[nation].rank(ascending=False).astype(int)
+    )
+
+# %% [markdown]
+# Response breakdown by nation: Proportions of subpopulation (95% confidence interval) (%)
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q11_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q12", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q12_nations_pct_df_ci = q12_nations_pct_df.copy(deep=True)
+q12_nations_pct_df_ci = q12_nations_pct_df_ci.astype(str)
+
+for index in q12_nations_pct_df_ci.index:
+    for response in q12_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q12_nations_pct_df_ci.loc[index, response] = (
+            f"""{q12_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+q12_nations_pct_df_ci = (
+    q12_nations_pct_df_ci.join(q12_nations_df["Nation total"])
+    .assign(**{"Nation total": lambda df: df["Nation total"].round(0).astype(int)})
+    .rename(columns={"Nation total": "n"})
+)
+
+# %%
+q12_nations_pct_df_ci.T.drop(columns="UK").join(
+    q12_nations_pct_df_compare[["England rank", "Scotland rank", "Wales rank"]]
+).sort_values(by="England rank", ascending=True)
+
+# %% [markdown]
+# ## RQ 7. UK and by nation: Benefits
+
+# %% [markdown]
+# The most commonly selected answer (33% of total UK) was that they would never get a heat pump. The next three most common answers were lowering energy bills (32%), environmental friendliness (29%) and independence from gas/oil/solid fuel (20%).
+#
+# The proportions across nations are similar.
+
+# %%
+benefit_options = [
+    benefit for benefit in code_question_lookup.keys() if "Q13_" in benefit
+]
+
+# %%
+multi_benefit_tables = {}
+for benefit in benefit_options:
+    if benefit == "PEN_Q13_collapsed":
+        pass
+    else:
+        counts, proportions = summary.create_nations_summary_tables(
+            q11_base_data, q11_base_data_wales, benefit, False
+        )
+        counts = counts.drop("Northern Ireland")
+        proportions = proportions.drop("Northern Ireland")
+        multi_benefit_tables[benefit] = {"counts": counts, "proportions": proportions}
+
+# %%
+# Summarise all benefits
+multi_benefit_counts = pd.DataFrame()
+multi_benefit_proportions = pd.DataFrame()
+for benefit in benefit_options:
+    if benefit == "PEN_Q13_collapsed":
+        pass
+    else:
+        multi_benefit_counts = pd.concat(
+            [multi_benefit_counts, multi_benefit_tables[benefit]["counts"]["True"]],
+            axis=1,
+        )
+        multi_benefit_proportions = pd.concat(
+            [
+                multi_benefit_proportions,
+                multi_benefit_tables[benefit]["proportions"]["True"],
+            ],
+            axis=1,
+        )
+
+barrier_column_names = []
+for benefit in benefit_options:
+    if benefit == "PEN_Q13_collapsed":
+        pass
+    else:
+        barrier_column_names.append(
+            f"{code_question_lookup.get(benefit).split(':')[1]}"
+        )
+
+for df in [multi_benefit_counts, multi_benefit_proportions]:
+    df.columns = barrier_column_names
+
+# %%
+multi_benefit_df = multi_benefit_proportions.reset_index().rename(
+    columns={"index": "Nation"}
+)
+multi_benefit_df_long = multi_benefit_df.melt(
+    id_vars="Nation", var_name="Benefit", value_name="Percentage"
+)
+
+sorted_order = multi_benefit_df_long[
+    multi_benefit_df_long["Nation"] == "England"
+].sort_values("Percentage", ascending=False)["Benefit"]
+
+plt.figure(figsize=(12, 6))
+ax = sns.barplot(
+    data=multi_benefit_df_long,
+    y="Benefit",
+    x="Percentage",
+    hue="Nation",
+    order=sorted_order,
+)
+ax.xaxis.grid(True, linestyle="-", alpha=0.3)
+plt.xlabel("Percentage (%)")
+plt.ylabel("Barrier")
+plt.legend(title="Nation")
+plt.tight_layout()
+plt.show()
+
+# %%
+# Compile 95% ci tables for each benefit and each nation
+benefit_proportions_ci = {}
+for nation, nation_data in q11_base_data_lookup.items():
+    nation_tables = {}
+    for benefit in benefit_options:
+        if benefit != "PEN_Q13_collapsed":
+            nation_tables[benefit] = (
+                summary.weighted_props_ci(nation_data, benefit, "weight") * 100
+            ).round(1)
+    benefit_proportions_ci[nation] = nation_tables
+
+# Modify original nation comparison tables with lower and upper CI values
+multi_benefit_proportions_with_ci = multi_benefit_proportions.copy(deep=True)
+multi_benefit_proportions_with_ci = multi_benefit_proportions_with_ci.astype(str)
+
+for benefit in benefit_options:
+    if benefit != "PEN_Q13_collapsed":
+        for index in multi_benefit_proportions_with_ci.index:
+            try:
+                lower = benefit_proportions_ci[index.lower()][benefit].loc[
+                    "True", "Lower CI"
+                ]
+            except KeyError:
+                lower = 0.0
+            try:
+                upper = benefit_proportions_ci[index.lower()][benefit].loc[
+                    "True", "Upper CI"
+                ]
+            except KeyError:
+                upper = 0.0
+
+            multi_benefit_proportions_with_ci.loc[
+                index, code_question_lookup.get(benefit).split(":")[1]
+            ] = f"""{multi_benefit_proportions_with_ci.loc[index, code_question_lookup.get(benefit).split(':')[1]]} ({lower}-{upper})"""
+
+# %%
+multi_benefit_proportions_with_ci.T
+
+# %%
+# Chi-squared contingency test across nations
+# Each benefit question
+
+for benefit in benefit_options:
+    if benefit != "PEN_Q13_collapsed":
+        chi2_stat, p_val, dof, expected = chi2_contingency(
+            multi_benefit_tables[benefit]["counts"].drop(
+                index="UK", columns="Nation total"
+            )
+        )
+
+        if p_val < 0.05:
+            print(
+                f"{benefit}: A chi-squared test of independence found a significant association between nations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+        else:
+            print(
+                f"{benefit}: A chi-squared test of independence showed no significant relationship between nations and response (χ²({dof}) = {chi2_stat:.2f}, p = {p_val:.2e})."
+            )
+
+# %% [markdown]
+# ## RQ 7. UK: Main benefit
+
+# %% [markdown]
+# The most common answer was that that they would never get a heat pump (33%). This is then followed by the benefits:
+# - Can lower energy bills (18%)
+# - More environmentally friendly (14%)
+# - Independence from gas/oil/solid fuel (5%)
+
+# %%
+# Summary dataframe
+q14_uk = summary.create_single_question_summary_frame(q11_base_data, "PEN_Q14")
+
+# Rename columns
+q14_uk.columns = ["Count", "Weighted count", "Percentage", "Weighted percentage"]
+
+# Drop redundant rows
+q14_uk = q14_uk.drop(index="Not asked").dropna().round(1)
+
+# Add confidence intervals for weighted proportions (95% ci)
+weighted_pct_ci = summary.weighted_props_ci(q11_base_data, "PEN_Q14", "weight") * 100
+q14_uk = q14_uk.join(weighted_pct_ci[["Lower CI", "Upper CI", "SE"]])
+
+# Display only select columns
+q14_uk = q14_uk.round(1)
+q14_uk[["Weighted count", "Weighted percentage", "Lower CI", "Upper CI", "SE"]]
+
+# %% [markdown]
+# ## RQ 7. By nation: Main benefit
+
+# %% [markdown]
+# Proportions are fairly similar across nations.
+#
+# The largest proportion for each nation (~33%) chose "Not applicable - I would never get a heat pump installed in my home"
+#
+# The ranking of top three main benefits for each nation is slightly different:
+# - England: Lower energy bills, More environmentally friendly, Independence from gas/oil/solid fuel
+# - Scotland: More environmentally friendly, Lower energy bills, Independence from gas/oil/solid fuel
+# - Wales: Lower energy bills, More environmentally friendly, Independence from gas/oil/solid fuel
+#
+# "Don't know" was also a common answer across nations (12-15%) - which is a lot higher than the proportions who said "Don't know" when asked about the main barrier (1-4%).
+
+# %%
+# Create comparison table for all nations and UK
+q14_nations_df, q14_nations_pct_df = summary.create_nations_summary_tables(
+    q11_base_data, q11_base_data_wales, "PEN_Q14", True
+)
+q14_nations_pct_df = q14_nations_pct_df.drop("Northern Ireland")
+
+# %%
+# Add rank columns for comparing ranks across nations
+q14_nations_pct_df_compare = q14_nations_pct_df.T.drop(columns="UK").sort_values(
+    by="England", ascending=False
+)
+for nation in ["England", "Scotland", "Wales"]:
+    q14_nations_pct_df_compare[f"{nation} rank"] = (
+        q14_nations_pct_df_compare[nation].rank(ascending=False).astype(int)
+    )
+
+# %% [markdown]
+# Response breakdown by nation: Proportions of subpopulation (95% confidence interval) (%)
+
+# %%
+# Compile 95% ci tables for each nation
+weighted_props_ci_nations = {}
+for nation, nation_data in q11_base_data_lookup.items():
+    weighted_props_ci_nations[nation] = (
+        summary.weighted_props_ci(nation_data, "PEN_Q14", "weight") * 100
+    ).round(1)
+
+# Modify original nation comparison table with lower and upper CI values
+q14_nations_pct_df_ci = q14_nations_pct_df.copy(deep=True)
+q14_nations_pct_df_ci = q14_nations_pct_df_ci.astype(str)
+
+for index in q14_nations_pct_df_ci.index:
+    for response in q14_nations_pct_df_ci.columns:
+        lower = weighted_props_ci_nations[index.lower()].loc[response, "Lower CI"]
+        upper = weighted_props_ci_nations[index.lower()].loc[response, "Upper CI"]
+        q14_nations_pct_df_ci.loc[index, response] = (
+            f"""{q14_nations_pct_df_ci.loc[index, response]} ({lower} - {upper})"""
+        )
+
+q14_nations_pct_df_ci = (
+    q14_nations_pct_df_ci.join(q12_nations_df["Nation total"])
+    .assign(**{"Nation total": lambda df: df["Nation total"].round(0).astype(int)})
+    .rename(columns={"Nation total": "n"})
+)
+
+# %%
+q14_nations_pct_df_ci.T.drop(columns="UK").join(
+    q14_nations_pct_df_compare[["England rank", "Scotland rank", "Wales rank"]]
+).sort_values(by="England rank", ascending=True)
+
+# %% [markdown]
+# ## RQ 7. Greater confidence on barriers compared to benefits
+
+# %% [markdown]
+# When asked about barriers or benefits that would prevent or encourage them from/to installing a heat pump in their home (select all factors questions), a much lower proportion of people said "Don't know" to barriers compared to benefits:
+#
+# - Barriers: 1.7% (1.3-2.1) selected "Don't know" (UK)
+#
+# - Benefits: 12.1% (11.1-13.0) selected "Don't know" (UK)
+#
+# This could suggest:
+#
+# - People are more confident identifying the barriers that would influence their decision-making rather than the benefits that would convince them
+#
+# - May be more important to focus on debunking misconceptions/lowering barriers
+#
+# - Knowledge gap about heat pump benefits and people may not have heard enough positive stories about heat pumps
+#
+# - There's still a lot of uncertainty and a lack of clarity on the positives of heat pumps
+
+# %% [markdown]
+# **The respondents who didn't know about benefits: What barriers did they select?**
+
+# %%
+# Respondents who said "Don't know" to benefits
+indices_to_check = []
+for i in q11_base_data[q11_base_data["PEN_Q13_977"] == "True"].index:
+    indices_to_check.append(i)
+
+# 539 respondents
+df = (
+    q11_base_data[q11_base_data["PEN_Q13_977"] == "True"]["PEN_Q12"]
+    .value_counts()
+    .to_frame(name="count")
+)
+df["percentage"] = ((df["count"] / df["count"].sum()) * 100).round(1)
+df[["percentage"]]
+
+# %% [markdown]
+# - A third of respondents who said "Don't know" to what heat pump benefits would encourage them to install one in their home selected "Too expensive to install" when asked about the one barrier that would prevent them the most.
+# - 90% of these respondents identified the biggest barrier for them (despite not identifying what the biggest encouragement for them would be). These respondents knew what would dissuade them, but didn't know what would persaude them.
+# - Does this suggest that people are more likely to know what would deter them from doing something, but are less clear on what would persuade them?
+
+# %%
+# Exploratory section
+
+# %%
+# # Checking what main barrier respondents selected
+# benefit = "Not applicable - I would never get a heat pump installed in my home"
+# filtered_benefit_data = data[
+#     ~(data["PEN_Q2_3_recoded"] == True)
+#     & (data["PEN_Q14"] == benefit)
+#     & (
+#         (data["profile_house_tenure"] == "Own - outright")
+#         | (data["profile_house_tenure"] == "Own - with a mortgage")
+#         | (
+#             data["profile_house_tenure"]
+#             == "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)"
+#         )
+#     )
+# ]
+# summary.create_single_question_summary_frame(filtered_benefit_data, "PEN_Q12", "weight")
+
+# %%
+# # Checking what main benefit respondents selected
+# barrier = "Too expensive to install"
+# filtered_barrier_data = data[
+#     ~(data["PEN_Q2_3_recoded"] == True)
+#     & (data["PEN_Q12"] == barrier)
+#     & (
+#         (data["profile_house_tenure"] == "Own - outright")
+#         | (data["profile_house_tenure"] == "Own - with a mortgage")
+#         | (
+#             data["profile_house_tenure"]
+#             == "Own (part-own) - through shared ownership scheme (i.e. pay part mortgage, part rent)"
+#         )
+#     )
+# ]
+# summary.create_single_question_summary_frame(filtered_barrier_data, "PEN_Q14", "weight")
+
+# %%
+# # Main benefit by age
+# df = pd.crosstab(
+#     index=q11_base_data["profile_julesage"],
+#     columns=q11_base_data["PEN_Q14"],
+#     values=q11_base_data["weight"],
+#     aggfunc="sum",
+#     normalize="index",
+# )
+# df["Total"] = df.sum(axis=1)
+# df = (df * 100).round(1)
+# df.T
+
+# %%
+# # Main benefit by income
+# counts_df, proportions_df = summary.generate_income_breakdown(q11_base_data, "PEN_Q14")
+# proportions_df
+
+# %%
+# # Main barrier by age
+# df = pd.crosstab(
+#     index=q11_base_data["profile_julesage"],
+#     columns=q11_base_data["PEN_Q12"],
+#     values=q11_base_data["weight"],
+#     aggfunc="sum",
+#     normalize="index",
+# )
+# df["Total"] = df.sum(axis=1)
+# df = (df * 100).round(1)
+# df.T
+
+# %%
+# # Main barrier by income
+# counts_df, proportions_df = summary.generate_income_breakdown(q11_base_data, "PEN_Q12")
+# proportions_df

--- a/asf_next_three_million_heat_pump_owners/notebooks/styles.css
+++ b/asf_next_three_million_heat_pump_owners/notebooks/styles.css
@@ -1,0 +1,18 @@
+.reveal table {
+  font-size: 20px;
+  border-collapse: collapse;
+}
+
+.reveal th,
+.reveal td {
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+}
+
+.reveal {
+  font-size: 2rem;
+}
+
+.reveal h2 {
+  font-size: 0.5rem;
+}

--- a/asf_next_three_million_heat_pump_owners/utils/summary.py
+++ b/asf_next_three_million_heat_pump_owners/utils/summary.py
@@ -1,4 +1,48 @@
 import pandas as pd
+from scipy.stats import norm
+import numpy as np
+import matplotlib.pyplot
+import matplotlib.pyplot as plt
+
+
+# --- Plotting ---
+
+
+def create_stacked_horizontal_bar_chart(
+    df: pd.DataFrame, xlabel: str, ylabel: str, fontsize: int, figsize: tuple
+) -> matplotlib.pyplot:
+    """
+    Creates a stacked horizontal bar chart from a DataFrame, with percentage labels displayed on each segment.
+    """
+    ax = df.plot(kind="barh", stacked=True, figsize=figsize, colormap="Dark2")
+    ax.set_xlabel(xlabel, fontsize=fontsize)
+    ax.set_ylabel(ylabel, fontsize=fontsize)
+    ax.tick_params(axis="x", labelsize=fontsize)
+    ax.tick_params(axis="y", labelsize=fontsize)
+    ax.legend(loc="center", bbox_to_anchor=(0.5, 1.1), ncol=2, fontsize=fontsize)
+    ax.set_xlim(0, 100)
+    ax.invert_yaxis()
+
+    # Add labels to each segment
+    for c in ax.containers:
+        for rect in c:
+            width = rect.get_width()
+            x_position = rect.get_x() + width / 2
+            y_position = rect.get_y() + rect.get_height() / 2
+            ax.text(
+                x_position,
+                y_position,
+                f"{width:.1f}%",
+                ha="center",
+                va="center",
+                fontsize=fontsize,
+                color="white",
+            )
+    plt.tight_layout()
+    return plt
+
+
+# --- Summarising single questions ---
 
 
 def create_single_question_summary_frame(
@@ -10,7 +54,7 @@ def create_single_question_summary_frame(
     """
 
     # Counts
-    df_counts = (
+    df_summary = (
         data[question_code]
         .value_counts(dropna=False)
         .reindex(data[question_code].cat.categories.append(pd.Index([pd.NA])))
@@ -18,31 +62,719 @@ def create_single_question_summary_frame(
     )
 
     # Weighted counts
-    df_counts["weighted_count"] = (
+    df_summary["weighted_count"] = (
         data.groupby(question_code, observed=True)[weight_column]
         .sum(min_count=1)
-        .reindex(df_counts.index, fill_value=0)
+        .reindex(df_summary.index, fill_value=0)
     )
 
     # Percentages
-    df_counts["percentage"] = (df_counts["count"] / df_counts["count"].sum()) * 100
+    df_summary["percentage"] = (df_summary["count"] / df_summary["count"].sum()) * 100
 
     # Weighted percentages
-    total_weighted_count = df_counts["weighted_count"].sum()
-    df_counts["weighted_percentage"] = (
-        df_counts["weighted_count"] / total_weighted_count
+    total_weighted_count = df_summary["weighted_count"].sum()
+    df_summary["weighted_percentage"] = (
+        df_summary["weighted_count"] / total_weighted_count
     ) * 100
 
     # Add total row
-    df_counts.loc["Total"] = [
-        df_counts["count"].sum(),
-        df_counts["weighted_count"].sum(),
-        df_counts["percentage"].sum(),
-        df_counts["weighted_percentage"].sum(),
+    df_summary.loc["Total"] = [
+        df_summary["count"].sum(),
+        df_summary["weighted_count"].sum(),
+        df_summary["percentage"].sum(),
+        df_summary["weighted_percentage"].sum(),
     ]
 
     # Round
-    df_counts["percentage"] = df_counts["percentage"].round(2)
-    df_counts["weighted_percentage"] = df_counts["weighted_percentage"].round(2)
+    df_summary["percentage"] = df_summary["percentage"].round(2)
+    df_summary["weighted_percentage"] = df_summary["weighted_percentage"].round(2)
 
-    return df_counts
+    return df_summary
+
+
+def create_nations_summary_tables(
+    base_data: pd.DataFrame,
+    wales_base_data: pd.DataFrame,
+    question_code: str,
+    remove_not_asked: bool = True,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Creates two summary DataFrames for a single question, one with weighted counts and one with
+    weighted percentages. Rows correspond to UK, and nation level data (England, Scotland, Wales and
+    Northern Ireland).
+    """
+
+    # Individual nation tables
+    england = (
+        pd.crosstab(
+            index=base_data["gornewUK_6"],
+            columns=base_data[question_code],
+            values=base_data["weight"],
+            aggfunc="sum",
+        )
+        .drop(index=False)
+        .rename(index={True: "England"})
+    )
+
+    scotland = (
+        pd.crosstab(
+            index=base_data["gornewUK_8"],
+            columns=base_data[question_code],
+            values=base_data["weight"],
+            aggfunc="sum",
+        )
+        .drop(index=False)
+        .rename(index={True: "Scotland"})
+    )
+
+    wales = pd.crosstab(
+        index=wales_base_data["gornewUK"],
+        columns=wales_base_data[question_code],
+        values=wales_base_data["weight"],
+        aggfunc="sum",
+    )
+
+    northern_ireland = (
+        pd.crosstab(
+            index=base_data["gornewUK_9"],
+            columns=base_data[question_code],
+            values=base_data["weight"],
+            aggfunc="sum",
+        )
+        .drop(index=False)
+        .rename(index={True: "Northern Ireland"})
+    )
+
+    uk = pd.crosstab(
+        index=base_data["UK18_Sept_2020_f_0"],
+        columns=base_data[question_code],
+        values=base_data["weight"],
+        aggfunc="sum",
+    ).rename(index={True: "UK"})
+
+    # Counts
+    df = pd.concat([england, scotland, wales, northern_ireland, uk])
+    df = df.reset_index(names="Nation")
+    df.set_index("Nation", inplace=True)
+
+    # Proportions
+    pct_df = (df.div(df.sum(axis=1), axis=0) * 100).round(1)
+    pct_df = pct_df.reset_index(names="Nation")
+    pct_df.set_index("Nation", inplace=True)
+
+    if remove_not_asked:
+        # Drop redundant columns
+        df = df.drop(columns="Not asked")
+        pct_df = pct_df.drop(columns="Not asked")
+
+    # Add national total columns
+    df["Nation total"] = df.sum(axis=1)
+
+    return df, pct_df
+
+
+# --- Generating confidence intervals ---
+
+
+def weighted_props_ci(
+    df: pd.DataFrame,
+    question_col: str,
+    weight_col: str = "weight",
+    z_percentile: float = 0.975,
+):
+    """
+    Creates a DataFrame of response proportions for a single question,
+    with lower and upper confidence intervals and standard error.
+    """
+
+    # z-score for normal distribution
+    z = norm.ppf(z_percentile)
+
+    # Weighted counts and proportions
+    weighted_counts = df.groupby(question_col, observed=False)[weight_col].sum()
+    total_weight = weighted_counts.sum()
+    props = weighted_counts / total_weight
+
+    # Effective sample size
+    n_eff = (df[weight_col].sum()) ** 2 / (df[weight_col] ** 2).sum()
+
+    # Standard errors
+    se = np.sqrt((props * (1 - props)) / n_eff)
+
+    # Confidence intervals
+    lower = (props - z * se).clip(lower=0.0)
+    upper = (props + z * se).clip(upper=1.0)
+
+    return pd.DataFrame(
+        {"Proportion": props, "Lower CI": lower, "Upper CI": upper, "SE": se}
+    )
+
+
+def weighted_props_ci_combine_categories(
+    results_df: pd.DataFrame,
+    cat1: str,
+    cat2: str,
+    new_cat_name: str = "Combined",
+    z_percentile: float = 0.975,
+) -> pd.Series:
+    """
+    Combines weighted percentages and standard errors of two categories, and computes the resulting
+    combined confidence interval and standard error.
+
+    Parameters
+    ----------
+    results_df : pd.DataFrame
+        A DataFrame indexed by category names, containing at least the columns 'Weighted percentage' and 'SE'.
+    cat1 : str
+        Name of the first category to combine.
+    cat2 : str
+        Name of the second category to combine.
+    new_cat_name : str, optional
+        Name to assign to the resulting combined category in the returned Series, by default "Combined".
+    z_percentile : float, optional
+        Percentile value used to calculate the z-score for the confidence interval, by default 0.975.
+
+    Returns
+    -------
+    pd.Series
+        A Series containing:
+            - Weighted percentage
+            - Lower CI
+            - Upper CI
+            - SE
+        Named according to `new_cat_name`.
+    """
+
+    # z-score for normal distribution
+    z = norm.ppf(z_percentile)
+
+    # Proportions and SEs for both categories
+    p1, se1 = results_df.loc[cat1, ["Weighted percentage", "SE"]]
+    p2, se2 = results_df.loc[cat2, ["Weighted percentage", "SE"]]
+
+    # Combine proportions
+    combined_p = p1 + p2
+
+    # Combine standard errors
+    combined_se = np.sqrt(se1**2 + se2**2)
+
+    # Combined confidence intervals
+    lower = combined_p - z * combined_se
+    upper = combined_p + z * combined_se
+
+    combined_result = pd.Series(
+        {
+            "Weighted percentage": combined_p,
+            "Lower CI": lower,
+            "Upper CI": upper,
+            "SE": combined_se,
+        },
+        name=new_cat_name,
+    )
+
+    return combined_result
+
+
+# --- Modifying dataframes with confidence intervals ---
+
+
+def modify_proportion_crosstab_with_ci(
+    base_data: pd.DataFrame,
+    proportions_df: pd.DataFrame,
+    aggregated_responses_column_dict: dict,
+    aggregated_responses_index_dict: dict,
+    index_survey_code: str,
+    z_percentile=0.975,
+) -> pd.DataFrame:
+    """
+    Adds confidence intervals to a crosstab of weighted proportions.
+
+    This function calculates confidence intervals for each proportion in a crosstab, taking into account
+    weights and effective sample size. It handles both individual and aggregated response categories
+    (in rows and columns). The output is a DataFrame where each proportion is formatted as:
+    "value (lower CI - upper CI)".
+
+    Parameters
+    ----------
+    base_data : pd.DataFrame
+        The raw survey dataset containing a column for respondent weights and survey codes.
+    proportions_df : pd.DataFrame
+        A crosstab DataFrame of weighted percentages (not proportions) indexed by category names.
+    aggregated_responses_column_dict : dict
+        A dictionary defining aggregated column (response) groupings, where keys are group names
+        and values are lists of original column labels to aggregate.
+    aggregated_responses_index_dict : dict
+        A dictionary defining aggregated index (group) groupings, where keys are group names
+        and values are lists of original index labels to aggregate.
+    index_survey_code : str
+        The column name in `base_data` used to match rows to the `proportions_df` index.
+    z_percentile : float, optional
+        The percentile value used to calculate the z-score for confidence intervals,
+        by default 0.975 (corresponding to ~95% confidence level).
+
+    Returns
+    -------
+    pd.DataFrame
+        A modified version of `proportions_df`, where each cell contains the original
+        percentage with its confidence interval in the format: "value (lower - upper)".
+    """
+
+    # Dataframes for storing CIs
+    ci_lower = pd.DataFrame(
+        index=proportions_df.index,
+        columns=proportions_df.columns,
+    )
+    ci_upper = pd.DataFrame(
+        index=proportions_df.index,
+        columns=proportions_df.columns,
+    )
+
+    # Non-aggregated responses
+    for index in proportions_df.index:
+        if "(net)" not in index and "Total" not in index:
+            for column in proportions_df.columns:
+                if "(net)" not in column and "Total" not in column:
+
+                    # Weighted counts and proportions
+                    group_data = base_data[base_data[index_survey_code] == index]
+                    weights = group_data["weight"]
+                    total_weight = weights.sum()
+                    weighted_proportion = proportions_df.loc[index, column] / 100
+
+                    # Effective sample size
+                    n_eff = (total_weight**2) / (weights**2).sum()
+
+                    # Standard error
+                    se = np.sqrt(
+                        weighted_proportion * (1 - weighted_proportion) / n_eff
+                    )
+
+                    # Confidence interval
+                    z = norm.ppf(z_percentile)
+                    lower = max(0.0, weighted_proportion - z * se)
+                    upper = min(1.0, weighted_proportion + z * se)
+
+                    ci_lower.loc[index, column] = round(lower * 100, 1)
+                    ci_upper.loc[index, column] = round(upper * 100, 1)
+
+    # Aggregated response columns
+    for index in proportions_df.index:
+        if "(net)" not in index and "Total" not in index:
+            for column in aggregated_responses_column_dict.keys():
+                # Weighted counts and proportions
+                group_data = base_data[base_data[index_survey_code] == index]
+                weights = group_data["weight"]
+                total_weight = weights.sum()
+                weighted_proportion = proportions_df.loc[index, column] / 100
+
+                # Effective sample size
+                n_eff = (total_weight**2) / (weights**2).sum()
+
+                # Standard error
+                se = np.sqrt(weighted_proportion * (1 - weighted_proportion) / n_eff)
+
+                # Confidence interval
+                z = norm.ppf(z_percentile)
+                lower = max(0.0, weighted_proportion - z * se)
+                upper = min(1.0, weighted_proportion + z * se)
+
+                ci_lower.loc[index, column] = round(lower * 100, 1)
+                ci_upper.loc[index, column] = round(upper * 100, 1)
+
+    # Aggregated response indices
+    for index in aggregated_responses_index_dict.keys():
+        for column in proportions_df.columns:
+            if "Total" not in column:
+
+                # Weighted counts and proportions
+                group_data = base_data[
+                    base_data[index_survey_code].isin(
+                        aggregated_responses_index_dict[index]
+                    )
+                ]
+                weights = group_data["weight"]
+                total_weight = weights.sum()
+                weighted_proportion = proportions_df.loc[index, column] / 100
+
+                # Effective sample size
+                n_eff = (total_weight**2) / (weights**2).sum()
+
+                # Standard error
+                se = np.sqrt(weighted_proportion * (1 - weighted_proportion) / n_eff)
+
+                # Confidence interval
+                z = norm.ppf(z_percentile)
+                lower = max(0.0, weighted_proportion - z * se)
+                upper = min(1.0, weighted_proportion + z * se)
+
+                ci_lower.loc[index, column] = round(lower * 100, 1)
+                ci_upper.loc[index, column] = round(upper * 100, 1)
+
+    # Modify original comparison table with lower and upper CI values
+    proportions_df_with_ci = proportions_df.copy(deep=True)
+    proportions_df_with_ci = proportions_df_with_ci.astype(str)
+    for index in proportions_df_with_ci.index:
+        if index != "Total":
+            for column in proportions_df_with_ci.columns:
+                if column != "Total":
+                    lower = ci_lower.loc[index, column]
+                    upper = ci_upper.loc[index, column]
+                    proportions_df_with_ci.loc[index, column] = (
+                        f"""{proportions_df.loc[index, column].round(1)} ({lower} - {upper})"""
+                    )
+
+    return proportions_df_with_ci
+
+
+# --- Summarising by tenure ---
+
+
+def generate_tenure_breakdown(
+    base_data: pd.DataFrame,
+    question: str,
+    response_aggregation_dict: dict = None,
+    proportions_axis: int = 1,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Generates weighted counts and proportions of responses to a question,
+    broken down by housing tenure. Optionally aggregates responses and tenure categories.
+
+    Parameters
+    ----------
+    base_data : pd.DataFrame
+        DataFrame containing the survey data, including weights, tenure, and question responses.
+    question : str
+        The column name of the question to analyse.
+    response_aggregation_dict : dict, optional
+        Dictionary mapping new column names to lists of response options to aggregate.
+        Used to create net categories from multiple response columns.
+    proportions_axis : int, default 1
+        If 1, calculates row-wise proportions (response breakdown of tenure).
+        If 0, calculates column-wise proportions (tenure breakdown of response).
+
+    Returns
+    -------
+    counts : pd.DataFrame
+        Weighted count of responses by tenure and response option.
+    proportions : pd.DataFrame
+        Proportions table based on counts table, expressed as percentages.
+    """
+
+    counts = pd.crosstab(
+        index=base_data["profile_house_tenure"],
+        columns=base_data[question],
+        values=base_data["weight"],
+        aggfunc="sum",
+    )
+
+    try:
+        counts = counts.drop(columns="Not asked")
+    except:
+        pass
+
+    # Proportions of each row (response breakdown of tenure)
+    if proportions_axis == 1:  # Total for each row
+        counts.loc["Total"] = counts.sum(axis=0)
+
+        # Aggregate tenure categories
+        for tenure in ["Own", "Rent", "Neither"]:
+            matching_rows = counts.loc[counts.index.str.contains(tenure)]
+            summed_row = matching_rows.sum()
+            counts.loc[f"{tenure} (net)"] = summed_row
+
+        proportions = (
+            counts.div(counts.sum(axis=proportions_axis), axis=0) * 100
+        ).round(1)
+
+        proportions["Total"] = proportions.sum(axis=1)
+        counts["Total"] = counts.sum(axis=1)
+
+        if response_aggregation_dict:
+            for df in [counts, proportions]:
+                for combined_col, source_cols in response_aggregation_dict.items():
+                    df[combined_col] = df[source_cols].sum(axis=1)
+
+    # Proportions of each column (tenure breakdown of response)
+    elif proportions_axis == 0:  # Total for each column
+        counts["Total"] = counts.sum(axis=1)
+
+        if response_aggregation_dict:
+            for combined_col, source_cols in response_aggregation_dict.items():
+                counts[combined_col] = counts[source_cols].sum(axis=1)
+
+        proportions = (
+            counts.div(counts.sum(axis=proportions_axis), axis=1) * 100
+        ).round(1)
+
+        counts.loc["Total"] = counts.sum(axis=0)
+        proportions.loc["Total"] = proportions.sum(axis=0)
+
+        # Aggregate tenure categories
+        for df in [counts, proportions]:
+            for tenure in ["Own", "Rent", "Neither"]:
+                matching_rows = df.loc[df.index.str.contains(tenure)]
+                summed_row = matching_rows.sum()
+                df.loc[f"{tenure} (net)"] = summed_row
+
+    else:
+        raise ValueError("Invalid axis argument, must be 0 or 1.")
+
+    return counts, proportions
+
+
+# --- Summarising by income ---
+
+
+def generate_income_breakdown(
+    base_data: pd.DataFrame,
+    question: str,
+    response_aggregation_dict: dict = None,
+    proportions_axis: int = 1,
+    aggregate_income: bool = True,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Generates weighted counts and proportions of responses to a question,
+    broken down by income bracket. Optionally aggregates responses and tenure categories.
+
+    Parameters
+    ----------
+    base_data : pd.DataFrame
+        DataFrame containing the survey data, including weights, income brackets, and question responses.
+    question : str
+        The column name of the question to analyse.
+    response_aggregation_dict : dict, optional
+        Dictionary mapping new column names to lists of response options to aggregate.
+        Used to create net categories from multiple response columns.
+    proportions_axis : int, default 1
+        If 1, calculates row-wise proportions (response breakdown of income).
+        If 0, calculates column-wise proportions (income breakdown of response).
+
+    Returns
+    -------
+    counts : pd.DataFrame
+        Weighted count of responses by income and response option.
+    proportions : pd.DataFrame
+        Proportions table based on counts table, expressed as percentages.
+    """
+
+    counts = pd.crosstab(
+        index=base_data["profile_gross_household"],
+        columns=base_data[question],
+        values=base_data["weight"],
+        aggfunc="sum",
+    )
+
+    try:
+        counts = counts.drop(columns="Not asked")
+    except:
+        pass
+
+    # Proportions of each row (response breakdown of tenure)
+    if proportions_axis == 1:  # Total for each row
+        counts.loc["Total"] = counts.sum(axis=0)
+
+        if aggregate_income:
+            # <£10k
+            matching_rows = counts.loc[
+                ["under £5,000 per year", "£5,000 to £9,999 per year"]
+            ]
+            summed_row = matching_rows.sum()
+            counts.loc["under £10,000 per year (net)"] = summed_row
+
+            # £10,000 to 29,999
+            matching_rows = counts.loc[
+                [
+                    "£10,000 to £14,999 per year",
+                    "£15,000 to £19,999 per year",
+                    "£20,000 to £24,999 per year",
+                    "£25,000 to £29,999 per year",
+                ]
+            ]
+            summed_row = matching_rows.sum()
+            counts.loc["£10,000 to £29,999 per year (net)"] = summed_row
+
+            # £30,000 to 49,999
+            matching_rows = counts.loc[
+                [
+                    "£30,000 to £34,999 per year",
+                    "£35,000 to £39,999 per year",
+                    "£40,000 to £44,999 per year",
+                    "£45,000 to £49,999 per year",
+                ]
+            ]
+            summed_row = matching_rows.sum()
+            counts.loc["£30,000 to £49,999 per year (net)"] = summed_row
+
+            # £50,000 to 69,999
+            matching_rows = counts.loc[
+                [
+                    "£50,000 to £59,999 per year",
+                    "£60,000 to £69,999 per year",
+                ]
+            ]
+            summed_row = matching_rows.sum()
+            counts.loc["£50,000 to £69,999 per year (net)"] = summed_row
+
+        proportions = (
+            counts.div(counts.sum(axis=proportions_axis), axis=0) * 100
+        ).round(1)
+
+        proportions["Total"] = proportions.sum(axis=1)
+        counts["Total"] = counts.sum(axis=1)
+
+        # Aggregate response categories
+        if response_aggregation_dict:
+            for df in [counts, proportions]:
+                for combined_col, source_cols in response_aggregation_dict.items():
+                    df[combined_col] = df[source_cols].sum(axis=1)
+
+    # Proportions of each column (tenure breakdown of response)
+    elif proportions_axis == 0:  # Total for each column
+        counts["Total"] = counts.sum(axis=1)
+
+        # Aggregate response categories
+        if response_aggregation_dict:
+            for combined_col, source_cols in response_aggregation_dict.items():
+                counts[combined_col] = counts[source_cols].sum(axis=1)
+
+        proportions = (
+            counts.div(counts.sum(axis=proportions_axis), axis=1) * 100
+        ).round(1)
+
+        counts.loc["Total"] = counts.sum(axis=0)
+        proportions.loc["Total"] = proportions.sum(axis=0)
+
+        if aggregate_income:
+            # Aggregate income categories
+            for df in [counts, proportions]:
+                # <£10k
+                matching_rows = df.loc[
+                    ["under £5,000 per year", "£5,000 to £9,999 per year"]
+                ]
+                summed_row = matching_rows.sum()
+                df.loc["under £10,000 per year (net)"] = summed_row
+                # £10,000 to 29,999
+                matching_rows = df.loc[
+                    [
+                        "£10,000 to £14,999 per year",
+                        "£15,000 to £19,999 per year",
+                        "£20,000 to £24,999 per year",
+                        "£25,000 to £29,999 per year",
+                    ]
+                ]
+                summed_row = matching_rows.sum()
+                df.loc["£10,000 to £29,999 per year (net)"] = summed_row
+                # £30,000 to 49,999
+                matching_rows = df.loc[
+                    [
+                        "£30,000 to £34,999 per year",
+                        "£35,000 to £39,999 per year",
+                        "£40,000 to £44,999 per year",
+                        "£45,000 to £49,999 per year",
+                    ]
+                ]
+                summed_row = matching_rows.sum()
+                df.loc["£30,000 to £49,999 per year (net)"] = summed_row
+                # £50,000 to 69,999
+                matching_rows = df.loc[
+                    [
+                        "£50,000 to £59,999 per year",
+                        "£60,000 to £69,999 per year",
+                    ]
+                ]
+                summed_row = matching_rows.sum()
+                df.loc["50,000 to £69,999 per year (net)"] = summed_row
+
+    else:
+        raise ValueError("Invalid axis argument, must be 0 or 1.")
+
+    return counts, proportions
+
+
+# --- Generating all summary tables for questions with responses to aggregate ---
+
+
+def generate_q5_outputs(
+    base_data, index_survey_code, drop_not_asked=True
+) -> tuple[dict[str, pd.DataFrame], pd.DataFrame]:
+    """
+    Generates weighted counts, proportions, and confidence intervals for responses to PEN_Q5,
+    broken down by a specified survey grouping variable.
+
+    Parameters
+    ----------
+    base_data : pd.DataFrame
+        The survey dataset containing response data, weights, and grouping codes.
+    index_survey_code : str
+        The name of the column in 'base_data' to group the PEN_Q5 responses by (e.g., age group, region).
+    drop_not_asked : bool, optional, default=True
+        Whether to drop rows and columns where the response is "Not asked".
+
+    Returns
+    -------
+    tuple[dict[str, pd.DataFrame], pd.DataFrame]
+        - A dictionary containing:
+            - "counts": Weighted counts of PEN_Q5 responses by group.
+            - "proportions": Proportions of PEN_Q5 responses by group, as percentages.
+              Both include net aggregated columns.
+        - A DataFrame of proportions with appended 95% confidence intervals for each response by group, with the "Total" column dropped.
+    """
+
+    ## Create Q5 response breakdown by response to other chosen question
+    q5_tables = {}
+
+    # Counts
+    q5_tables["counts"] = pd.crosstab(
+        index=base_data[index_survey_code],
+        columns=base_data["PEN_Q5"],
+        values=base_data["weight"],
+        aggfunc="sum",
+        margins=True,
+        margins_name="Total",
+    )
+
+    # Proportions
+    q5_tables["proportions"] = pd.crosstab(
+        index=base_data[index_survey_code],
+        columns=base_data["PEN_Q5"],
+        values=base_data["weight"],
+        aggfunc="sum",
+        normalize="index",
+    )
+    q5_tables["proportions"]["Total"] = q5_tables["proportions"].sum(axis=1)
+    q5_tables["proportions"] = (q5_tables["proportions"] * 100).round(1)
+
+    # Add aggregated responses
+    for df in q5_tables.values():
+        df["Would consider (net)"] = (
+            df["Definitely would consider"] + df["Probably would consider"]
+        )
+        df["Wouldn't consider (net)"] = (
+            df["Definitely wouldn't consider"] + df["Probably wouldn't consider"]
+        )
+        df.drop(columns="Not asked", inplace=True)
+    if drop_not_asked:
+        q5_tables["proportions"] = q5_tables["proportions"].drop(index="Not asked")
+
+    ## 95% confidence intervals for proportions
+    # Aggregated responses to PEN_Q5
+    aggregated_responses_q5 = {
+        "Would consider (net)": [
+            "Definitely would consider",
+            "Probably would consider",
+        ],
+        "Wouldn't consider (net)": [
+            "Definitely wouldn't consider",
+            "Probably would consider",
+        ],
+    }
+
+    q5_proportions_with_ci = modify_proportion_crosstab_with_ci(
+        base_data=base_data,
+        proportions_df=q5_tables["proportions"],
+        aggregated_responses_column_dict=aggregated_responses_q5,
+        aggregated_responses_index_dict={},
+        index_survey_code=index_survey_code,
+    ).drop(columns="Total")
+
+    return q5_tables, q5_proportions_with_ci

--- a/asf_next_three_million_heat_pump_owners/utils/summary.py
+++ b/asf_next_three_million_heat_pump_owners/utils/summary.py
@@ -14,7 +14,8 @@ def create_stacked_horizontal_bar_chart(
     """
     Creates a stacked horizontal bar chart from a DataFrame, with percentage labels displayed on each segment.
     """
-    ax = df.plot(kind="barh", stacked=True, figsize=figsize, colormap="Dark2")
+    fig, ax = plt.subplots(figsize=figsize, layout="constrained")
+    df.plot(kind="barh", stacked=True, colormap="Dark2", ax=ax)
     ax.set_xlabel(xlabel, fontsize=fontsize)
     ax.set_ylabel(ylabel, fontsize=fontsize)
     ax.tick_params(axis="x", labelsize=fontsize)
@@ -38,8 +39,7 @@ def create_stacked_horizontal_bar_chart(
                 fontsize=fontsize,
                 color="white",
             )
-    plt.tight_layout()
-    return plt
+    return fig
 
 
 # --- Summarising single questions ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=2.2.3
 openpyxl>=3.1.5
 numpy>=2.2.4
 pyarrow>=19.0.0
+quarto>=1.5.55


### PR DESCRIPTION
---

In this PR, I've added 5 notebooks the research questions we set out. I decided to split them up into separate files because rendering a combined mega notebook using quarto led to some issues.
The intention is to render each .ipynb using quarto to reveal slides. You can find preliminary versions of rendered slides in the shared google folder.
Some cells are commented out as they were for exploratory purposes, and I didn't want them included in the slides for sharing.

Due to the timeline we received the Wales boost dataset, I've included the file for cleaning that set in this PR. It is follows the exact approach for each question as the cleaning process for the main dataset.

# Instructions for Reviewer

For this PR, please could you check that I've handled the data correctly to generate the intended tables. Apologies for the spaghetti nature of the code due to manipulating the tables to be the way I wanted them displayed. 

In particular, please have a closer look at the functions in the summary.py module which calculate lower and upper confidence intervals.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
